### PR TITLE
Modify print bleed to be two dimensional to reduce white borders

### DIFF
--- a/utilities.py
+++ b/utilities.py
@@ -84,15 +84,43 @@ def get_back_card_image_path(back_dir_path) -> str | None:
     else:
         raise Exception(f'Back image directory path "{back_dir_path}" contains more than one image. Files include "{files}".')
 
-def draw_card_with_border(card_image: Image, base_image: Image, box: tuple[int, int, int, int], print_bleed: int):
+def draw_card_with_bleed(card_image: Image, base_image: Image, box: tuple[int, int, int, int], print_bleed: tuple[int, int]):
     origin_x, origin_y, origin_width, origin_height = box
 
-    # Draw the card multiple times with different dimensions to create print bleed
-    for i in reversed(range(print_bleed)):
-        card_image_resize = card_image.resize((origin_width + (2 * i), origin_height + (2 * i)))
-        base_image.paste(card_image_resize, (origin_x - i, origin_y - i))
+    
+    left = print_bleed[0]
+    right = print_bleed[0]
+    top = print_bleed[1]
+    bottom = print_bleed[1]
 
-def draw_card_layout(card_images: List[Image.Image], base_image: Image.Image, num_rows: int, num_cols: int, x_pos: List[int], y_pos: List[int], width: int, height: int, print_bleed: int, crop: float, ppi_ratio: float, extend_corners: int, flip: bool):
+    width, height = card_image.size
+    base_image.paste(card_image, (origin_x + left, origin_y + top))
+    
+    def extend_edge(crop_box, start, bleed, axis):
+        for i in range(bleed):
+            pos = (start[0] + (i if axis == 0 else 0), start[1] + (i if axis == 1 else 0))
+            base_image.paste(card_image.crop(crop_box), pos)
+
+    # Extend the edges of the cards to create print bleed
+    # Top and bottom
+    extend_edge((0, 0, width, 1), (origin_x + left, origin_y), top, 1)
+    extend_edge((0, height-1, width, height), (origin_x + left, origin_y + top + height), bottom, 1)
+
+    # Left and right
+    extend_edge((0, 0, 1, height), (origin_x, origin_y + top), left, 0)
+    extend_edge((width-1, 0, width, height), (origin_x + left + width, origin_y + top), right, 0)
+
+    # Corners
+    for x, crop_x, pos_x in [(left, 0, origin_x), (right, width-1, origin_x + left + width)]:
+        for y, crop_y, pos_y in [(top, 0, origin_y), (bottom, height-1, origin_y + top + height)]:
+            for i in range(x):
+                for j in range(y):
+                    base_image.paste(card_image.crop((crop_x, crop_y, crop_x+1, crop_y+1)), (pos_x + i, pos_y + j))
+
+    return base_image
+
+
+def draw_card_layout(card_images: List[Image.Image], base_image: Image.Image, num_rows: int, num_cols: int, x_pos: List[int], y_pos: List[int], width: int, height: int, print_bleed: tuple[int, int], crop: float, ppi_ratio: float, extend_corners: int, flip: bool):
     num_cards = num_rows * num_cols
 
     # Fill all the spaces with the card back
@@ -121,11 +149,11 @@ def draw_card_layout(card_images: List[Image.Image], base_image: Image.Image, nu
         extend_corners_ppi = math.floor(extend_corners * ppi_ratio)
         card_image = card_image.crop((extend_corners_ppi, extend_corners_ppi, card_image.width - extend_corners_ppi, card_image.height - extend_corners_ppi))
 
-        draw_card_with_border(
+        draw_card_with_bleed(
             card_image,
             base_image,
             (new_origin_x + extend_corners_ppi, new_origin_y + extend_corners_ppi, math.floor(width * ppi_ratio) - (2 * extend_corners_ppi), math.floor(height * ppi_ratio) - (2 * extend_corners_ppi)),
-            math.ceil(print_bleed * ppi_ratio) + extend_corners_ppi
+            tuple(math.ceil(bleed * ppi_ratio) + extend_corners_ppi for bleed in print_bleed)
         )
 
 def add_front_back_pages(front_page: Image.Image, back_page: Image.Image, pages: List[Image.Image], page_width: int, page_height: int, ppi_ratio: float, template: str, only_fronts: bool, name: str):
@@ -459,7 +487,7 @@ def offset_images(images: List[Image.Image], x_offset: int, y_offset: int, ppi: 
 
 def calculate_max_print_bleed(x_pos: List[int], y_pos: List[int], width: int, height: int) -> int:
     if len(x_pos) == 1 & len(y_pos) == 1:
-        return 0
+        return (0, 0)
 
     x_border_max = 100000
     if len(x_pos) >= 2:
@@ -485,4 +513,4 @@ def calculate_max_print_bleed(x_pos: List[int], y_pos: List[int], width: int, he
         if y_border_max < 0:
             y_border_max = 100000
 
-    return min(x_border_max, y_border_max) + 1
+    return (x_border_max, y_border_max)

--- a/utilities.py
+++ b/utilities.py
@@ -94,8 +94,8 @@ def draw_card_with_bleed(card_image: Image, base_image: Image, box: tuple[int, i
     bottom = print_bleed[1]
 
     width, height = card_image.size
-    base_image.paste(card_image, (origin_x + left, origin_y + top))
-    
+    base_image.paste(card_image, (origin_x, origin_y))
+
     def extend_edge(crop_box, start, bleed, axis):
         for i in range(bleed):
             pos = (start[0] + (i if axis == 0 else 0), start[1] + (i if axis == 1 else 0))
@@ -103,16 +103,16 @@ def draw_card_with_bleed(card_image: Image, base_image: Image, box: tuple[int, i
 
     # Extend the edges of the cards to create print bleed
     # Top and bottom
-    extend_edge((0, 0, width, 1), (origin_x + left, origin_y), top, 1)
-    extend_edge((0, height-1, width, height), (origin_x + left, origin_y + top + height), bottom, 1)
+    extend_edge((0, 0, width, 1), (origin_x, origin_y - top), top, 1)
+    extend_edge((0, height-1, width, height), (origin_x, origin_y + height), bottom, 1)
 
     # Left and right
-    extend_edge((0, 0, 1, height), (origin_x, origin_y + top), left, 0)
-    extend_edge((width-1, 0, width, height), (origin_x + left + width, origin_y + top), right, 0)
+    extend_edge((0, 0, 1, height), (origin_x - left, origin_y), left, 0)
+    extend_edge((width-1, 0, width, height), (origin_x + width, origin_y), right, 0)
 
     # Corners
-    for x, crop_x, pos_x in [(left, 0, origin_x), (right, width-1, origin_x + left + width)]:
-        for y, crop_y, pos_y in [(top, 0, origin_y), (bottom, height-1, origin_y + top + height)]:
+    for x, crop_x, pos_x in [(left, 0, origin_x - left), (right, width-1, origin_x + width)]:
+        for y, crop_y, pos_y in [(top, 0, origin_y - top), (bottom, height-1, origin_y + height)]:
             for i in range(x):
                 for j in range(y):
                     base_image.paste(card_image.crop((crop_x, crop_y, crop_x+1, crop_y+1)), (pos_x + i, pos_y + j))


### PR DESCRIPTION
If the cards don't have a 1:1 aspect ratio then white lines can appear in the generated bleed. In most cases this is not an issue since the silhouette cuts so accurately with the registration marks, but on printers without duplex it's often harder to align the backs.

This change modifies the generated bleed border to be two dimensional. As part of it has to change the way the bleed is generated to render the edges multiple times instead of scaling the images with two different directions for performance reasons.