### PR TITLE
Use filetype library instead of relying on file extensions for file filtering

### DIFF
--- a/utilities.py
+++ b/utilities.py
@@ -399,9 +399,7 @@ def generate_pdf(
     back_card_image_path = None
     use_default_back_page = True
     if not only_fronts:
-        print(back_dir_path, back_card_image_path)
         back_card_image_path = get_back_card_image_path(back_dir_path)
-        print(back_dir_path, back_card_image_path)
         use_default_back_page = back_card_image_path is None
         if use_default_back_page:
             print(f'No back image provided in back image directory \"{back_dir_path}\". Using default instead.')


### PR DESCRIPTION
Changes `utilities.py` to use the standard library `mimetypes` for recognizing file types, instead of only filtering by `.md` files. Can cause less issues if a user's directory has other non-image files in it