### PR TITLE
Update dependencies to support Python 3.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 click==8.1.8
 natsort==8.4.0
-numpy==2.1.1
+numpy==2.3.3
 Pillow==11.3.0
-pydantic==2.11.1
+pydantic==2.12.0
 Requests==2.32.3
 pypdfium2==4.30.0
 split-image==2.0.1


### PR DESCRIPTION
Fixes an issue with using Python 3.14 to generate PDFs. Only requirements that require bumps are pydantic and numpy, both of which are used in a way that isn't affected by the update