### PR TITLE
Add support for dual-sided MTG tokens (i.e. Start Your Engines!)

### DIFF
--- a/plugins/mtg/scryfall.py
+++ b/plugins/mtg/scryfall.py
@@ -4,7 +4,7 @@ import re
 import requests
 import time
 
-double_sided_layouts = ['transform', 'modal_dfc']
+double_sided_layouts = ['transform', 'modal_dfc', 'double_faced_token']
 
 def request_scryfall(
     query: str,


### PR DESCRIPTION
Added feature for dual-sided MTG tokens. Utilizes the `double_faced_token` layout of the Scryfall API to fetch the backs of said tokens