### PR TITLE
Fix Piltover Archive Images for the Riftbound Plugin

### DIFF
--- a/plugins/riftbound/api.py
+++ b/plugins/riftbound/api.py
@@ -4,7 +4,7 @@ from enum import Enum
 import time
 import requests
 
-PILTOVER_URL_TEMPLATE = 'https://piltoverarchive.com/_next/image?url=https://cdn.piltoverarchive.com/cards/{card_number}.webp&w=1920&q=75'
+PILTOVER_URL_TEMPLATE = 'https://cdn.piltoverarchive.com/cards/{card_number}.webp'
 RIFTMANA_URL_TEMPLATE = 'https://riftmana.com/wp-content/uploads/Cards/{card_number}.webp'
 
 class ImageServer(str, Enum):


### PR DESCRIPTION
The images can no longer be retrieved from Piltover Archive following a recent update to their NextJS backend logic that removed image optimization. This PR seeks to remedy that issue.