### PR TITLE
Fix Riftbound Card Number Retrieval

### DIFF
--- a/plugins/riftbound/api.py
+++ b/plugins/riftbound/api.py
@@ -46,21 +46,21 @@ def fetch_card_art(index: int, card_number: str, quantity: int, source: ImageSer
                     f.write(card_art)
 
 def fetch_card_number(name: str) -> str:
-    # Edge case of cards that are misnamed on the backend
-    if name == "Spirit's Refuge":
-        name = "Spirit's Rifuge"
+    # # Edge case of cards that are misnamed on the backend
+    # if name == "Spirit's Refuge":
+    #     name = "Spirit's Rifuge"
 
-    # Get the internal information based on the card name to route to the card itself
-    sanitized = sub(r'[^A-Za-z0-9 \-]+', '', name)
-    slugified = sub(r'\s+', '-', sanitized).lower()
+    # # Get the internal information based on the card name to route to the card itself
+    # sanitized = sub(r'[^A-Za-z0-9 \-]+', '', name)
+    # slugified = sub(r'\s+', '-', sanitized).lower()
 
-    url = f"https://riftmana.com/wp-json/wp/v2/card-name?search={slugified}"
+    url = f"https://riftmana.com/wp-json/wp/v2/cards?search={name}"
     name_response = request_api(url)
 
     # Now we can retrieve the card number
-    card_link = name_response.json()[0].get('_links', {}).get('wp:post_type')[0].get('href')
+    card_link = name_response.json()[0].get('_links', {}).get('self')[0].get('href')
     card_response = request_api(card_link)
-    card_number_and_name = card_response.json()[0].get('title').get('rendered')
+    card_number_and_name = card_response.json().get('title').get('rendered')
 
     # '{Card Number} {Card Name}'
     pattern = compile(r'^([A-Z0-9]+-\d+[a-z]?)(\s+|-)(.*)$')

--- a/plugins/riftbound/api.py
+++ b/plugins/riftbound/api.py
@@ -1,5 +1,5 @@
 from os import path
-from re import compile, search, sub
+from re import compile, search
 from enum import Enum
 import time
 import requests
@@ -46,14 +46,6 @@ def fetch_card_art(index: int, card_number: str, quantity: int, source: ImageSer
                     f.write(card_art)
 
 def fetch_card_number(name: str) -> str:
-    # # Edge case of cards that are misnamed on the backend
-    # if name == "Spirit's Refuge":
-    #     name = "Spirit's Rifuge"
-
-    # # Get the internal information based on the card name to route to the card itself
-    # sanitized = sub(r'[^A-Za-z0-9 \-]+', '', name)
-    # slugified = sub(r'\s+', '-', sanitized).lower()
-
     url = f"https://riftmana.com/wp-json/wp/v2/cards?search={name}"
     name_response = request_api(url)
 


### PR DESCRIPTION
This PR aims to fix the issue where card numbers can no longer be retrieved from Riftmana. This appeared due to Riftmana changing their API endpoint from ``https://riftmana.com/wp-json/wp/v2/card-search`` to ``https://riftmana.com/wp-json/wp/v2/cards``. In the process, they modified how individual card link references are retrieved and made it possible to bypass incorrectly named cards in their database.