### PR TITLE
Fix Star Wars Unlimited Fetch from swu-db

### DIFF
--- a/plugins/star_wars_unlimited/swudb.py
+++ b/plugins/star_wars_unlimited/swudb.py
@@ -40,6 +40,12 @@ def fetch_name_and_title(card_id: str) -> card_tuple:
 
         title = json.get('Subtitle') or '' if json.get('Type') != 'Base' else ''
 
+        # These are incorrectly hosted by swu-db
+        if name == 'Darth Tyrannus':
+            name = 'Darth Tyranus'
+        if title == 'Darth Tyrannus':
+            title = 'Darth Tyranus'
+
         return (name, title)
     
     else:

--- a/test/test_star_wars_unlimited_plugin.py
+++ b/test/test_star_wars_unlimited_plugin.py
@@ -1,0 +1,14 @@
+from plugins.star_wars_unlimited.swudb import fetch_name_and_title, request_swudb, SWUDB_CARD_NUMBER_URL_TEMPLATE
+
+def test_tyrannus_typo():
+  # SWUDB incorrectly returns subtitle Darth Tyrannus for Count Dooku card
+  # The correct subtitle is Darth Tyranus
+  json = request_swudb(SWUDB_CARD_NUMBER_URL_TEMPLATE.format(set_id="SOR", set_number="304")).json()
+  raw_name = json.get('Name')
+  raw_title = json.get('Subtitle') or '' if json.get('Type') != 'Base' else ''
+  assert raw_name == "Count Dooku"
+  assert raw_title == "Darth Tyrannus"
+
+  name, title = fetch_name_and_title("SOR_304")
+  assert name == "Count Dooku"
+  assert title == "Darth Tyranus"


### PR DESCRIPTION
This PR aims to fix the retrievals associated with the incorrect labeling on swu-db for Darth Tyrannus.
Currently, ``Count Dooku - Darth Tyrannus`` is the only known disparity.