### PR TITLE
Rewrite MPCFill plugin to handle double-sided decks

### DIFF
--- a/plugins/mtg/deck_formats.py
+++ b/plugins/mtg/deck_formats.py
@@ -227,6 +227,12 @@ def parse_scryfall_json(deck_text, handle_card: Callable) -> None:
             handle_card(index, name, set_code, collector_number, quantity)
 
 # MPCFill XML
+def _extract_card_name(raw_name: str) -> str:
+    """Extract card name by stripping the file extension (e.g. 'Mountain.png' -> 'Mountain')."""
+    parts = raw_name.split(".")
+    return ".".join(parts[:-1]) if len(parts) > 1 else parts[0]
+
+
 def extract_mpcfill_card_ids(deck_text: str) -> set[str]:
     """Extract all unique card IDs from MPCFill XML for prefetching."""
     data = ET.fromstring(deck_text)
@@ -269,8 +275,7 @@ def parse_mpcfill_xml(deck_text, handle_card: Callable) -> None:
     # Assign fronts to ALL their slots
     for front in fronts.findall("card"):
         card_id = front.find("id").text
-        name_parts = front.find("name").text.split(".")
-        name = ".".join(name_parts[:-1]) if len(name_parts) > 1 else name_parts[0]
+        name = _extract_card_name(front.find("name").text)
         slot_indices = [int(s) for s in front.find("slots").text.split(",")]
         for slot_idx in slot_indices:
             slots[slot_idx]["front_id"] = card_id
@@ -280,8 +285,7 @@ def parse_mpcfill_xml(deck_text, handle_card: Callable) -> None:
     if backs:
         for back in backs.findall("card"):
             card_id = back.find("id").text
-            name_parts = back.find("name").text.split(".")
-            name = ".".join(name_parts[:-1]) if len(name_parts) > 1 else name_parts[0]
+            name = _extract_card_name(back.find("name").text)
             slot_indices = [int(s) for s in back.find("slots").text.split(",")]
             for slot_idx in slot_indices:
                 slots[slot_idx]["back_id"] = card_id

--- a/plugins/mtg/fetch.py
+++ b/plugins/mtg/fetch.py
@@ -5,7 +5,7 @@ import click
 
 from deck_formats import DeckFormat, parse_deck, extract_mpcfill_card_ids
 from scryfall import get_handle_card as scryfall_get_handle_card
-from mpcfill import get_handle_card as mpc_get_handle_card, prefetch_images
+from mpcfill import get_handle_card as mpc_get_handle_card, prefetch_mpcfill
 
 front_directory = os.path.join('game', 'front')
 double_sided_directory = os.path.join('game', 'double_sided')
@@ -36,35 +36,29 @@ def cli(
         print(f'{deck_path} is not a valid file.')
         return
     
-    if format == DeckFormat.MPCFILL_XML:
-        get_handle_card = mpc_get_handle_card(
-            front_directory,
-            double_sided_directory
-        )
-    else:
-        get_handle_card = scryfall_get_handle_card(
-            ignore_set_and_collector_number,
+    with open(deck_path, 'r') as deck_file:
+        deck_text = deck_file.read()
 
-            prefer_older_sets,
-            prefer_set,
-            
-            prefer_showcase,
-            prefer_extra_art,
-            tokens,
+        if format == DeckFormat.MPCFILL_XML:
+            get_handle_card = mpc_get_handle_card(
+                front_directory,
+                double_sided_directory
+            )
+            prefetch_mpcfill(extract_mpcfill_card_ids(deck_text))
+        else:
+            get_handle_card = scryfall_get_handle_card(
+                ignore_set_and_collector_number,
 
-            front_directory,
-            double_sided_directory
-        )
+                prefer_older_sets,
+                prefer_set,
 
-    # If format is URL, skip reading file and pass URL as deck_text (deck_url for parse_url()).
-    if format == DeckFormat.URL:
-        parse_deck(deck_path, format, get_handle_card)
-        return
+                prefer_showcase,
+                prefer_extra_art,
+                tokens,
 
-    # For MPCFill XML, prefetch all unique images in parallel before processing
-    if format == DeckFormat.MPCFILL_XML:
-        card_ids = extract_mpcfill_card_ids(deck_text)
-        prefetch_images(card_ids)
+                front_directory,
+                double_sided_directory
+            )
 
     parse_deck(
         deck_text,

--- a/plugins/mtg/mpcfill.py
+++ b/plugins/mtg/mpcfill.py
@@ -1,3 +1,22 @@
+"""
+MPCFill image fetching and caching.
+
+The MPCFill API is a Google Apps Script that returns base64-encoded card images.
+Each HTTP request has significant latency due to the Google Apps Script cold-start
+overhead, so fetching images one at a time is very slow for large decks.
+
+To speed this up, prefetch_mpcfill() uses a ThreadPoolExecutor to fetch multiple
+images at the same time. A ThreadPoolExecutor creates a pool of worker threads
+(up to MAX_WORKERS) that each make HTTP requests independently. This means
+instead of waiting for one request to finish before starting the next, up to
+MAX_WORKERS requests can be in flight simultaneously.
+
+All fetched images are stored in _image_cache so that duplicate card IDs
+(e.g. 4 copies of the same card across different slots) only require one
+network request. When write_slot_image() is called for each slot, it pulls
+from the cache via get_cached_image() instead of hitting the network again.
+"""
+
 import os
 from base64 import b64decode
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -8,10 +27,13 @@ from filetype.filetype import guess_extension
 
 from common import remove_nonalphanumeric
 
-# Cache for fetched images: card_id -> decoded image bytes
+# Cache for fetched images: card_id -> decoded image bytes.
+# Populated by prefetch_mpcfill() and read by get_cached_image().
 _image_cache: dict[str, bytes] = {}
 
-# Number of parallel workers for fetching
+# Maximum number of concurrent HTTP requests during prefetching.
+# Each worker thread fetches one image at a time, so 8 workers means
+# up to 8 simultaneous downloads.
 MAX_WORKERS = 8
 
 
@@ -24,7 +46,7 @@ def request_mpcfill(card_id: str) -> bytes:
 
 
 def _fetch_single(card_id: str) -> tuple[str, bytes | None]:
-    """Fetch a single card and return (card_id, image_bytes)."""
+    """Fetch a single card, returning None on failure instead of raising."""
     try:
         image_bytes = request_mpcfill(card_id)
         return (card_id, image_bytes)
@@ -33,9 +55,16 @@ def _fetch_single(card_id: str) -> tuple[str, bytes | None]:
         return (card_id, None)
 
 
-def prefetch_images(card_ids: Set[str]) -> None:
-    """Prefetch all unique card images in parallel and cache them."""
-    # Filter out already cached IDs
+def prefetch_mpcfill(card_ids: Set[str]) -> None:
+    """
+    Fetch all unique card images in parallel and store them in _image_cache.
+
+    Uses ThreadPoolExecutor to run up to MAX_WORKERS downloads concurrently.
+    executor.submit() schedules _fetch_single for each card ID, returning a
+    Future object that will hold the result once the download completes.
+    as_completed() then yields each Future as it finishes (not necessarily in
+    submission order), allowing us to process results as soon as they're ready.
+    """
     ids_to_fetch = [cid for cid in card_ids if cid not in _image_cache]
 
     if not ids_to_fetch:
@@ -44,9 +73,13 @@ def prefetch_images(card_ids: Set[str]) -> None:
     print(f"Prefetching {len(ids_to_fetch)} images with {MAX_WORKERS} workers...")
 
     with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        # Submit all fetch tasks to the thread pool. Each call returns a Future
+        # representing the pending result. We map each Future back to its card_id.
         futures = {executor.submit(_fetch_single, card_id): card_id for card_id in ids_to_fetch}
 
         completed = 0
+        # as_completed() yields futures in the order they finish, so we can
+        # cache results as soon as each download completes.
         for future in as_completed(futures):
             card_id, image_bytes = future.result()
             if image_bytes is not None:
@@ -59,7 +92,7 @@ def prefetch_images(card_ids: Set[str]) -> None:
 
 
 def get_cached_image(card_id: str) -> bytes | None:
-    """Get an image from cache, fetching if not present."""
+    """Get an image from cache, fetching on-demand if not already cached."""
     if card_id not in _image_cache:
         _, image_bytes = _fetch_single(card_id)
         if image_bytes:


### PR DESCRIPTION
Previously broken decklist:

```
<order>
    <details>
        <quantity>75</quantity>
        <bracket>90</bracket>
        <stock>(S30) Standard Smooth</stock>
        <foil>false</foil>
    </details>
    <fronts>
        <card>
            <id>1fHFn9gK63EJkN61xx3sdp2LPjDEJgt4a</id>
            <slots>0,1,2,3</slots>
            <name>Burning-Tree Emissary.png</name>
            <query>burning tree emissary</query>
        </card>
        <card>
            <id>122TroDKGpEPTiTDihS8I33xPAKdSD1yC</id>
            <slots>4,5</slots>
            <name>Chain Lightning.png</name>
            <query>chain lightning</query>
        </card>
        <card>
            <id>1z9ftw5cL8vpszBnnluP58Z59_fGHOfMw</id>
            <slots>6,7,8,9</slots>
            <name>Clockwork Percussionist (a).png</name>
            <query>clockwork percussionist</query>
        </card>
        <card>
            <id>1vrJjDEytXH3O_2zaG6SItT7mrcr17-lJ</id>
            <slots>10,63,64</slots>
            <name>End the Festivities.png</name>
            <query>end festivities</query>
        </card>
        <card>
            <id>1HTFwDOI4maerCrbZCN5Y9pfvHoNpWOd0</id>
            <slots>11,12,13</slots>
            <name>Experimental Synthesizer.png</name>
            <query>experimental synthesizer</query>
        </card>
        <card>
            <id>1Gl5_KfS9AEYPvCOLCX9qznnl1Exp2PP5</id>
            <slots>14,15,16,17</slots>
            <name>Galvanic Blast.jpg</name>
            <query>galvanic blast</query>
        </card>
        <card>
            <id>12V5CsNWkJg1tGe-5t8lUVmdlQj2Y02B4</id>
            <slots>18,19,20,21</slots>
            <name>Goblin Bushwhacker.png</name>
            <query>goblin bushwhacker</query>
        </card>
        <card>
            <id>172FzpL38tjyw6YgflVwUMpneMOLv66j0</id>
            <slots>22,23,24,25</slots>
            <name>Goblin Tomb Raider.png</name>
            <query>goblin tomb raider</query>
        </card>
        <card>
            <id>1qV3aLKDRwMD8r1dl3fmAst28nzrgwmQ7</id>
            <slots>26,27,28,29</slots>
            <name>Great Furnace.jpg</name>
            <query>great furnace</query>
        </card>
        <card>
            <id>10CNN72lnTzYL6JOtRYNr4E9G7ENJMcl9</id>
            <slots>30,31,32,33</slots>
            <name>Lightning Bolt.png</name>
            <query>lightning bolt</query>
        </card>
        <card>
            <id>1cUj_XiS8NG4FOVItS0SeD6xiPCZ6S7BY</id>
            <slots>34,35,36,37,38,39,40,41,42,43,44,45,46,47</slots>
            <name>Mountain (Sam Burley).jpg</name>
            <query>mountain</query>
        </card>
        <card>
            <id>1CvJSXmj6pVWO9BFFx1vp_irnxu7JJnK8</id>
            <slots>48,49,50,51</slots>
            <name>Rally at the Hornburg.png</name>
            <query>rally at hornburg</query>
        </card>
        <card>
            <id>1C7H8HMIUOwZ-GbbQKZgozz05gpM_AALK</id>
            <slots>52,53,54,55</slots>
            <name>Reckless Impulse.png</name>
            <query>reckless impulse</query>
        </card>
        <card>
            <id>1GsdY9-8L00s5777aSIultBA4xNEnKWfS</id>
            <slots>56,57,58,59</slots>
            <name>Voldaren Epicure.png</name>
            <query>voldaren epicure</query>
        </card>
        <card>
            <id>1LGhsChmibB-a1jss69pG55c5sxAmJ3ry</id>
            <slots>60,61,62</slots>
            <name>Cast into the Fire.png</name>
            <query>cast into fire</query>
        </card>
        <card>
            <id>1LtXI7vbhyt30LzEMoBsxf_s-1KSYBa6z</id>
            <slots>65</slots>
            <name>Flaring Pain.jpg</name>
            <query>flaring pain</query>
        </card>
        <card>
            <id>1B6-96Aj6u-yj3oPwLaMzcgqFV69oeRya</id>
            <slots>66</slots>
            <name>Flash of Defiance.jpg</name>
            <query>flash of defiance</query>
        </card>
        <card>
            <id>1WxyLfhADG1_KPaSxawc_BDZcdE3E7_Om</id>
            <slots>67,68,69</slots>
            <name>Red Elemental Blast.png</name>
            <query>red elemental blast</query>
        </card>
        <card>
            <id>1o4i5_n-JPVxwy2aSlpO8gmxfqKftymcQ</id>
            <slots>70,71,72</slots>
            <name>Relic of Progenitus.png</name>
            <query>relic of progenitus</query>
        </card>
        <card>
            <id>1TnW9hO5YwgMI0XtG2HuB4vVuUlMuJitk</id>
            <slots>73,74</slots>
            <name>Searing Blaze.png</name>
            <query>searing blaze</query>
        </card>
    </fronts>
    <backs>
        <card>
            <id>1NUz1MASblkDTKo_TrQPieFsO4hMAfKph</id>
            <slots>0,1,2,3</slots>
            <name>Avenging Hunter.png</name>
            <query>avenging hunter</query>
        </card>
        <card>
            <id>1AGZjITL6_U024Tm_g5pUv8Zya8DoFdzw</id>
            <slots>4,5,6,7</slots>
            <name>Elvish Mystic (Borderless Greg Staples).jpg</name>
            <query>elvish mystic</query>
        </card>
        <card>
            <id>1zuPhuaV8Ck8i7GC8vCqT4wFTtjNOxZUD</id>
            <slots>8,9,10</slots>
            <name>Fyndhorn Elves (Igor Kieryluk).jpg</name>
            <query>fyndhorn elves</query>
        </card>
        <card>
            <id>1sO9UkDKw10mYiwMmkVjXplOzD5LmvBvQ</id>
            <slots>11,12,13,14</slots>
            <name>Generous Ent.png</name>
            <query>generous ent</query>
        </card>
        <card>
            <id>13-n3hMfTD4MFWbvNpTSq71DbvNhzZESf</id>
            <slots>15,16,17,18</slots>
            <name>Lead the Stampede (Classic Promo Lius Lasahido).jpg</name>
            <query>lead stampede</query>
        </card>
        <card>
            <id>1gndGvlfZ7HZdOTIXXoJ7BG19R-KxjYn1</id>
            <slots>19,20</slots>
            <name>Llanowar Elves (Borderless kozyndan).jpg</name>
            <query>llanowar elves</query>
        </card>
        <card>
            <id>12PwcI3bjCsbEqYi3My2ymtnBBQATfBNN</id>
            <slots>21,22,23,24</slots>
            <name>Masked Vandal (Shifted).jpg</name>
            <query>masked vandal</query>
        </card>
        <card>
            <id>1eD6xclw35a1TYVQkvmjJsWJo16kz9OMs</id>
            <slots>25,26,27,28</slots>
            <name>Nyxborn Hydra.png</name>
            <query>nyxborn hydra</query>
        </card>
        <card>
            <id>13KnQA9ANF5DhBtxwkWLe_zduWOHnszTm</id>
            <slots>29,30,31,32</slots>
            <name>Priest of Titania.png</name>
            <query>priest of titania</query>
        </card>
        <card>
            <id>18H4ktTrzUXaeq9tGVaxBoYlTHhNAkbn8</id>
            <slots>33,34,35,36</slots>
            <name>Quirion Ranger.jpg</name>
            <query>quirion ranger</query>
        </card>
        <card>
            <id>1gh78Jfrrch-2MREhhzfn_NPIOlE3RacR</id>
            <slots>37,38,39,40,41,42,43,44,45,46,47,48,49</slots>
            <name>Snow-Covered Forest (Classic Promo Adam Paquette).jpg</name>
            <query>snow covered forest</query>
        </card>
        <card>
            <id>1AFvvkizbSH_CxbWZCjrMmj3Y1bb9Q7Ll</id>
            <slots>50,51,52,53</slots>
            <name>Timberwatch Elf.jpg</name>
            <query>timberwatch elf</query>
        </card>
        <card>
            <id>1zDbQDryRyD1Nrgg45JmOgdUlkBcTEpQU</id>
            <slots>54,55</slots>
            <name>Wellwisher.png</name>
            <query>wellwisher</query>
        </card>
        <card>
            <id>1qYyywgkOkUUc4bn24GaSVKrRCdWBVjzs</id>
            <slots>56,57,58,59</slots>
            <name>Winding Way.jpg</name>
            <query>winding way</query>
        </card>
        <card>
            <id>14erGUyNWjtZYhYp5uXQG7VuOqc9Sfawh</id>
            <slots>60</slots>
            <name>Gingerbread Cabin.png</name>
            <query>gingerbread cabin</query>
        </card>
        <card>
            <id>15OYhiGuoe_P5KitRhhUHXAu3jmx1gHJk</id>
            <slots>61,62,63,64</slots>
            <name>Monstrous Emergence.png</name>
            <query>monstrous emergence</query>
        </card>
        <card>
            <id>1D9CRNUpufNhx-BZEUxsyp73zxyDj9sqR</id>
            <slots>65,66,67</slots>
            <name>Pulse of Murasa.png</name>
            <query>pulse of murasa</query>
        </card>
        <card>
            <id>1ZRtIeRXbjnUsypwYXmmNk5MxoyFO00rP</id>
            <slots>68,69,70</slots>
            <name>Spinewoods Paladin.jpg</name>
            <query>spinewoods paladin</query>
        </card>
        <card>
            <id>1mDH5JY2aNREWi27GK1VzF97X1uv8oi9l</id>
            <slots>71,72,73,74</slots>
            <name>Vitu-Ghazi Inspector.png</name>
            <query>vitu ghazi inspector</query>
        </card>
    </backs>
    <cardback>1LrVX0pUcye9n_0RtaDNVl2xPrQgn7CYf</cardback>
</order>
```