### PR TITLE
Fix Pokemon plugin non numerical card number

### DIFF
--- a/plugins/pokemon/deck_formats.py
+++ b/plugins/pokemon/deck_formats.py
@@ -2,7 +2,7 @@ from re import compile
 from enum import Enum
 from typing import Callable, Tuple
 
-card_data_tuple = Tuple[str, int, str, int] # Name, Quantity, Set ID, Card Number
+card_data_tuple = Tuple[str, int, str, str] # Name, Quantity, Set ID, Card Number
 
 def parse_deck_helper(deck_text: str, handle_card: Callable, is_card_line: Callable[[str], bool], extract_card_data: Callable[[str], card_data_tuple]) -> None:
     error_lines = []
@@ -32,7 +32,7 @@ def parse_deck_helper(deck_text: str, handle_card: Callable, is_card_line: Calla
         print(f'Errors: {error_lines}')
 
 def parse_limitless(deck_text: str, handle_card: Callable) -> None:
-    pattern = compile(r'^(\d+)\s(.+)\s(.+)\s(\d+)$') # '{Quantity} {Name} {Set} {Number}'
+    pattern = compile(r'^(\d+)\s(.+)\s(\S+)\s(\S+)$') # '{Quantity} {Name} {Set} {Number}'
 
     def is_limitless_line(line) -> bool:
         return bool(pattern.match(line))
@@ -43,7 +43,7 @@ def parse_limitless(deck_text: str, handle_card: Callable) -> None:
             card_name = match.group(2).strip()
             quantity = int(match.group(1).strip())
             set_id = match.group(3).strip()
-            card_number = int(match.group(4).strip())
+            card_number = match.group(4).strip()
 
             return (card_name, quantity, set_id, card_number)
 

--- a/plugins/pokemon/limitless.py
+++ b/plugins/pokemon/limitless.py
@@ -30,7 +30,7 @@ def request_pokemontcg(url: str, params: dict = None) -> Response:
 
     return r
 
-def fetch_card_from_pokemontcg(card_name: str, card_number: int) -> bytes:
+def fetch_card_from_pokemontcg(card_name: str, card_number: str) -> bytes:
     search_query = f'name:"{card_name}" number:{card_number}'
     response = request_pokemontcg(POKEMONTCG_API_URL, params={'q': search_query})
     data = response.json()
@@ -51,7 +51,7 @@ def fetch_card(
     quantity: int,
     card_name: str,
     set_id: str,
-    card_number: int,
+    card_number: str,
     front_img_dir: str,
 ):
     card_art = None
@@ -92,7 +92,7 @@ def fetch_card(
 def get_handle_card(
     front_img_dir: str,
 ):
-    def configured_fetch_card(index: int, card_name: str, set_id: str, card_number: int, quantity: int = 1):
+    def configured_fetch_card(index: int, card_name: str, set_id: str, card_number: str, quantity: int = 1):
         fetch_card(
             index,
             quantity,


### PR DESCRIPTION
Previously non-working deck:

```
Pokémon: 15
1 Feebas DRM 28
1 Milotic PRC 44
1 Hisuian Basculin ASR 43
1 Hisuian Basculegion PR-SW SWSH205
1 Manaphy CRZ GG6
1 Remoraid PAR 33
1 Octillery BKT 33
1 Snom MEG 42
1 Frosmoth SHF SV34
1 Sobble MEG 39
1 Drizzile SHF SV26
1 Inteleon SHF SV27
1 Wailmer JTG 40
1 Wailord JTG 162
1 Wishiwashi CEC 240

Trainer: 36
1 Buddy-Buddy Poffin TWM 223
1 Capacious Bucket RCL 156
1 Devolution Spray EVO 76
1 Dive Ball PRC 161
1 Earthen Vessel SFA 96
1 Escape Rope BUS 163
1 Field Blower GRI 163
1 Hisuian Heavy Ball ASR 146
1 Level Ball BST 181
1 Nest Ball SUM 158
1 Night Stretcher MEG 173
1 Professor's Letter BKT 146a
1 Quick Ball SSH 216
1 Scoop Up Net RCL 207
1 Super Rod PAL 276
1 Superior Energy Retrieval PAL 277
1 Ultra Ball PLF 122
1 VS Seeker ROS 110
1 Air Balloon SSH 213
1 Float Stone PLF 99
1 Luxurious Cape PAR 265
1 Brooklet Hill HIF SV88
1 Rough Seas PRC 137
1 Arezu LOR 189
1 Avery CRE 187
1 Ball Guy SHF 65
1 Gladion CIN 109
1 Guzma HIF SV84
1 Hex Maniac AOR 75a
1 Iono PAL 269
1 Irida CRZ GG63
1 Lillie's Determination MEG 184
1 Mallow & Lana CEC 231
1 N FCO 105a
1 Nessa LOR TG27
1 Teammates PRC 160

Energy: 8
6 Water Energy CL 90
1 Reversal Energy PAR 266
1 Splash Energy BKP 113
```