### PR TITLE
Add `--bleed_percent` option to create_pdf.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,18 +232,19 @@ Options:
                                   Examples: 3mm, 0.125in, 6.5.
   --extend_corners INTEGER RANGE  Reduce artifacts produced by rounded corners
                                   in card images.  [default: 0; x>=0]
+  --bleed_percent INTEGER RANGE   Amount of print bleed. 100 is full bleed, 0
+                                  is no bleed.  [default: 100; 0<=x<=100]
   --ppi INTEGER RANGE             Pixels per inch (PPI) when creating PDF.
-                                  [default: 300; x>=0]
   --quality INTEGER RANGE         File compression. A higher value corresponds
                                   to better quality and larger file size.
-                                  [default: 75; 0<=x<=100]
+                                  [default: 75; 0<=x<=100]     
   --load_offset                   Apply saved offsets. See `offset_pdf.py` for
                                   more information.
   --skip INTEGER RANGE            Skip a card based on its index. Useful for
                                   registration issues. Examples: 0, 4.  [x>=0]
   --name TEXT                     Label each page of the PDF with a name.
-  --version                       Show the version and exit.
-  --help                          Show this message and exit.
+  --version                       Show the version and exit.   
+  --help                          Show this message and exit. 
 ```
 
 ### Examples

--- a/create_pdf.py
+++ b/create_pdf.py
@@ -25,6 +25,7 @@ default_output_path = os.path.join(output_directory, 'game.pdf')
 @click.option("--crop", help="Crop the outer portion of front and double-sided images. Examples: 3mm, 0.125in, 6.5.")
 @click.option("--crop_backs", help="Crop the outer portion of back images. Examples: 3mm, 0.125in, 6.5.")
 @click.option("--extend_corners", default=0, type=click.IntRange(min=0), show_default=True, help="Reduce artifacts produced by rounded corners in card images.")
+@click.option("--bleed_percent", default=100, type=click.IntRange(min=0, max=100), show_default=True, help="Amount of print bleed. 100 is full bleed, 0 is no bleed.")
 @click.option("--ppi", default=300, type=click.IntRange(min=0), show_default=True, help="Pixels per inch (PPI) when creating PDF.")
 @click.option("--quality", default=75, type=click.IntRange(min=0, max=100), show_default=True, help="File compression. A higher value corresponds to better quality and larger file size.")
 @click.option("--load_offset", default=False, is_flag=True, help="Apply saved offsets. See `offset_pdf.py` for more information.")
@@ -46,6 +47,7 @@ def cli(
     crop,
     crop_backs,
     extend_corners,
+    bleed_percent,
     ppi,
     quality,
     skip,
@@ -66,6 +68,7 @@ def cli(
         crop,
         crop_backs,
         extend_corners,
+        bleed_percent,
         ppi,
         quality,
         skip,

--- a/hugo/content/docs/create.md
+++ b/hugo/content/docs/create.md
@@ -150,18 +150,19 @@ Options:
                                   Examples: 3mm, 0.125in, 6.5.
   --extend_corners INTEGER RANGE  Reduce artifacts produced by rounded corners
                                   in card images.  [default: 0; x>=0]
+  --bleed_percent INTEGER RANGE   Amount of print bleed. 100 is full bleed, 0
+                                  is no bleed.  [default: 100; 0<=x<=100]
   --ppi INTEGER RANGE             Pixels per inch (PPI) when creating PDF.
-                                  [default: 300; x>=0]
   --quality INTEGER RANGE         File compression. A higher value corresponds
                                   to better quality and larger file size.
-                                  [default: 75; 0<=x<=100]
+                                  [default: 75; 0<=x<=100]     
   --load_offset                   Apply saved offsets. See `offset_pdf.py` for
                                   more information.
   --skip INTEGER RANGE            Skip a card based on its index. Useful for
                                   registration issues. Examples: 0, 4.  [x>=0]
   --name TEXT                     Label each page of the PDF with a name.
-  --version                       Show the version and exit.
-  --help                          Show this message and exit.
+  --version                       Show the version and exit.   
+  --help                          Show this message and exit. 
 ```
 
 ## Examples

--- a/utilities.py
+++ b/utilities.py
@@ -512,6 +512,7 @@ def generate_pdf(
     crop_string: str | None,
     crop_backs_string: str | None,
     extend_corners: int,
+    bleed_percent: int,
     ppi: int,
     quality: int,
     skip_indices: List[int],
@@ -623,6 +624,7 @@ def generate_pdf(
             pages: List[Image.Image] = []
 
             max_print_bleed = calculate_max_print_bleed(card_layout.x_pos, card_layout.y_pos, card_layout_size.width, card_layout_size.height, MINIMUM_BLEED)
+            max_print_bleed = (math.floor(max_print_bleed[0] * bleed_percent / 100), math.floor(max_print_bleed[1] * bleed_percent / 100))
 
             # Load and cache the single back image for reuse
             # Do this if we expect both front and back pages and if we have a back image


### PR DESCRIPTION
This gives the user some control over the bleed amount.

The main use case is for users to see what the cut cards should look like by setting `bleed_percent` to 0.

I'm hesitant to merge this in for a few reasons

I don't like how the scale is 0-100. The only other option that is similar is `quality`. However, if we went with this, I'd rather change `quality` to `quality_percent` to match. However, `quality` is one of the more common used options so I need to think more carefully about the deprecation.

I don't think `bleed_percent` will be used very often. With #106 , I'm planning on standardizing the bleed amount to be 0.625mm. In that case, there's even less need to have a lot of bleed customization.

Maybe the option should just be a boolean, whether to turn on bleed or not, or maybe it should be some kind of overlay that uses dxf to draw the outline of the card.