### PR TITLE
Fix Scryfall rate limits and introduce persistent sessions

### DIFF
--- a/plugins/mtg/scryfall.py
+++ b/plugins/mtg/scryfall.py
@@ -39,12 +39,21 @@ def request_scryfall(
 ) -> requests.Response:
     r = requests.get(query, params=params, headers = {'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
 
-    # Check for 2XX response code
+
+    # Rate limit check
+    if r.status_code == 429:
+        time.sleep(1)
+        return request_scryfall(query, params)
+
     r.raise_for_status()
 
-    # Sleep for 75 milliseconds, greater than the 50 ms requested by Scryfall API documentation
+    # Sleep for 500ms or 100ms milliseconds, which is requested by Scryfall API documentation
     # See rate limits: https://scryfall.com/docs/api
-    time.sleep(0.075)
+
+    if "cards/search" in query or "cards/named" in query:
+        time.sleep(0.5)   # 2/second (500ms)
+    elif "api.scryfall.io" not in query:
+        time.sleep(0.11)  # All other API methods 10/second (100ms)
 
     return r
 

--- a/plugins/mtg/scryfall.py
+++ b/plugins/mtg/scryfall.py
@@ -38,23 +38,30 @@ def fetch_printings(prints_search_uri: str, prefer_ub: Optional[bool], name: str
 def request_scryfall(
     query: str,
     params: dict = None,
+    retry_count: int = 0,
 ) -> requests.Response:
-    r = scryfall.get(query, params=params, headers = {'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'}) # Should be a lot smoother and nicer to Scryfall servers.
+    r = scryfall.get(query, params=params, headers = {'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
 
-    # Rate limit check
+    # Rate limit check - Scryfall requires 30 second wait per their documentation
     if r.status_code == 429:
-        time.sleep(30) # Let us wait 30 seconds so we don't get blocked.
-        return request_scryfall(query, params)
+        if retry_count >= 3:
+            print(f"Warning: Hit rate limit 3 times for {query}, giving up after 30s wait")
+            raise requests.exceptions.HTTPError(f"Max retries (3) exceeded for Scryfall API: {query}", response=r)
+        print(f"Hit Scryfall rate limit (429), waiting 30 seconds before retry {retry_count + 1}/3...")
+        time.sleep(30)
+        return request_scryfall(query, params, retry_count + 1)
 
     r.raise_for_status()
 
-    # Sleep for 500ms or 100ms milliseconds, which is requested by Scryfall API documentation
-    # See rate limits: https://scryfall.com/docs/api
+    # Apply rate limiting per Scryfall API documentation
+    # See: https://scryfall.com/docs/api/rate-limits
+    # Note: Direct image downloads from *.scryfall.io CDN have NO rate limits
 
     if "cards/search" in query or "cards/named" in query:
-        time.sleep(0.5)   # 2/second (500ms) - Required limit as requested by Scryfall
-    elif 'api.scryfall.com' in query: # Catch all for other queries (And slightly over the time to be safe)
-        time.sleep(0.11)  # All other API methods 10/second (100ms)
+        time.sleep(0.5)   # Search/named endpoints: 2 requests/second (500ms delay)
+    elif 'api.scryfall.com' in query:
+        time.sleep(0.1)  # All other API methods: 10 requests/second (100ms delay)
+    # else: No rate limiting needed for direct image downloads from *.scryfall.io CDN
 
     return r
 

--- a/plugins/mtg/scryfall.py
+++ b/plugins/mtg/scryfall.py
@@ -11,7 +11,7 @@ from .common import remove_nonalphanumeric, ScryfallLanguage, to_scryfall_api_la
 
 double_sided_layouts = ['transform', 'modal_dfc', 'double_faced_token', 'reversible_card', 'meld']
 
-scryfall = requests.Session()
+session = requests.Session()
 
 def append_search_filter(uri: str, filter_term: str) -> str:
     parsed = urlparse(uri)
@@ -40,7 +40,7 @@ def request_scryfall(
     params: dict = None,
     retry_count: int = 0,
 ) -> requests.Response:
-    r = scryfall.get(query, params=params, headers = {'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
+    r = session.get(query, params=params, headers = {'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
 
     # Rate limit check - Scryfall requires 30 second wait per their documentation
     if r.status_code == 429:

--- a/plugins/mtg/scryfall.py
+++ b/plugins/mtg/scryfall.py
@@ -11,6 +11,8 @@ from .common import remove_nonalphanumeric, ScryfallLanguage, to_scryfall_api_la
 
 double_sided_layouts = ['transform', 'modal_dfc', 'double_faced_token', 'reversible_card', 'meld']
 
+scryfall = requests.Session()
+
 def append_search_filter(uri: str, filter_term: str) -> str:
     parsed = urlparse(uri)
     params = parse_qs(parsed.query, keep_blank_values=True)
@@ -37,12 +39,11 @@ def request_scryfall(
     query: str,
     params: dict = None,
 ) -> requests.Response:
-    r = requests.get(query, params=params, headers = {'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
-
+    r = scryfall.get(query, params=params, headers = {'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'}) # Should be a lot smoother and nicer to Scryfall servers.
 
     # Rate limit check
     if r.status_code == 429:
-        time.sleep(1)
+        time.sleep(30) # Let us wait 30 seconds so we don't get blocked.
         return request_scryfall(query, params)
 
     r.raise_for_status()
@@ -51,8 +52,8 @@ def request_scryfall(
     # See rate limits: https://scryfall.com/docs/api
 
     if "cards/search" in query or "cards/named" in query:
-        time.sleep(0.5)   # 2/second (500ms)
-    elif "api.scryfall.io" not in query:
+        time.sleep(0.5)   # 2/second (500ms) - Required limit as requested by Scryfall
+    elif 'api.scryfall.com' in query: # Catch all for other queries (And slightly over the time to be safe)
         time.sleep(0.11)  # All other API methods 10/second (100ms)
 
     return r

--- a/test/test_mtg_plugin.py
+++ b/test/test_mtg_plugin.py
@@ -1087,12 +1087,16 @@ class TestUniverseBeyondScryfallData:
     """Sanity checks that the Scryfall data for our test cards matches expectations.
 
     If these fail it means the cards have received new printings that change their
-    UB/non-UB composition — update the URIs/set codes below and re-check the
+    UB/non-UB composition — update the URIs below and re-check the
     filtering tests, rather than assuming the plugin is broken.
+
+    Oracle IDs verified from stable card IDs:
+    - Skrelv: https://api.scryfall.com/cards/509c00d2-6a84-4760-8927-483ed123b05f
+    - Excalibur: https://api.scryfall.com/cards/4e357b2d-a3c1-490e-a37c-cdf42abcfa60
     """
 
-    SKRELV_PRINTS_URI = 'https://api.scryfall.com/cards/search?order=released&q=oracleid%3A48354be0-40ff-4f8f-a0e7-dc3e20bcf6ba&unique=prints'
-    EXCALIBUR_PRINTS_URI = 'https://api.scryfall.com/cards/search?order=released&q=oracleid%3A1d1695a2-1d5e-42b1-9e59-a6c51b2b2f80&unique=prints'
+    SKRELV_PRINTS_URI = 'https://api.scryfall.com/cards/search?order=released&q=oracleid%3A20053847-6623-493c-8cdb-a69cda3b1577&unique=prints'
+    EXCALIBUR_PRINTS_URI = 'https://api.scryfall.com/cards/search?order=released&q=oracleid%3A9fb6bd72-031b-40a1-83c5-8a1c82f84e12&unique=prints'
 
     def test_skrelv_has_ub_printing(self):
         """Scryfall still lists a UB printing of Skrelv (SLD 1926)."""
@@ -1129,12 +1133,14 @@ class TestUniverseBeyondFiltering:
     Skrelv, Defector Mite exists as both a standard printing (ONE 225)
     and a Universe Beyond printing (SLD 1926).
     Excalibur, Sword of Eden only exists as a Universe Beyond printing (ACR 72).
+
+    Oracle IDs verified from stable card IDs:
+    - Skrelv: https://api.scryfall.com/cards/509c00d2-6a84-4760-8927-483ed123b05f
+    - Excalibur: https://api.scryfall.com/cards/4e357b2d-a3c1-490e-a37c-cdf42abcfa60
     """
 
-    # prints_search_uri for Skrelv, Defector Mite
-    SKRELV_PRINTS_URI = 'https://api.scryfall.com/cards/search?order=released&q=oracleid%3A48354be0-40ff-4f8f-a0e7-dc3e20bcf6ba&unique=prints'
-    # prints_search_uri for Excalibur, Sword of Eden
-    EXCALIBUR_PRINTS_URI = 'https://api.scryfall.com/cards/search?order=released&q=oracleid%3A1d1695a2-1d5e-42b1-9e59-a6c51b2b2f80&unique=prints'
+    SKRELV_PRINTS_URI = 'https://api.scryfall.com/cards/search?order=released&q=oracleid%3A20053847-6623-493c-8cdb-a69cda3b1577&unique=prints'
+    EXCALIBUR_PRINTS_URI = 'https://api.scryfall.com/cards/search?order=released&q=oracleid%3A9fb6bd72-031b-40a1-83c5-8a1c82f84e12&unique=prints'
 
     def test_prefer_ub_returns_only_ub_printings(self):
         """prefer_ub=True returns only Universe Beyond printings of Skrelv."""

--- a/test/test_mtg_plugin.py
+++ b/test/test_mtg_plugin.py
@@ -603,7 +603,7 @@ class TestScryfallFetch:
 
         mock_fetch_art.assert_called_once()
 
-    @patch('plugins.mtg.scryfall.requests.get')
+    @patch('plugins.mtg.scryfall.scryfall.get')
     def test_image_fetched_with_lowercase_set_code(self, mock_get):
         """When given an uppercase set code, the image is fetched using the lowercase code returned by the API."""
         info_response = MagicMock(status_code=200)

--- a/test/test_mtg_plugin.py
+++ b/test/test_mtg_plugin.py
@@ -603,7 +603,7 @@ class TestScryfallFetch:
 
         mock_fetch_art.assert_called_once()
 
-    @patch('plugins.mtg.scryfall.scryfall.get')
+    @patch('plugins.mtg.scryfall.session.get')
     def test_image_fetched_with_lowercase_set_code(self, mock_get):
         """When given an uppercase set code, the image is fetched using the lowercase code returned by the API."""
         info_response = MagicMock(status_code=200)


### PR DESCRIPTION
Introduced sessions to keep a persistent connection open to Scryfall.

Fixed backwards rate-limit check that was accidentally sleeping on direct image downloads (*.scryfall.io has no limit as per their documentation).

Also fixed our 429 retry to wait 30 seconds instead of 1 second, so Scryfall doesn't get upset.

Scryfall should be a lot more happy with us now and decks should download smoothly now.