### PR TITLE
docs: rename Netrunner plugin display name to Android: Netrunner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ plugins/<game>/
 
 Plugins read decklists and download card images to `game/front/` (and `game/double_sided/` for double-faced cards).
 
-Supported games include: MTG, Yu-Gi-Oh!, Pokemon, Lorcana, Digimon, One Piece, Flesh and Blood, Star Wars: Unlimited, Grand Archive, Gundam, Netrunner, Altered, Ashes Reborn, Elestrals, and Riftbound.
+Supported games include: MTG, Yu-Gi-Oh!, Pokemon, Lorcana, Digimon, One Piece, Flesh and Blood, Star Wars: Unlimited, Grand Archive, Gundam, Android: Netrunner, Altered, Ashes Reborn, Elestrals, and Riftbound.
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The [Gundam plugin](plugins/gundam/README.md) supports **DeckPlanet**, **Egman E
 
 The [Lorcana plugin](plugins/lorcana/README.md) supports **Dreamborn** format.
 
-The [Netrunner plugin](plugins/netrunner/README.md) supports **bbCode** and **Jinteki** formats.
+The [Android: Netrunner plugin](plugins/netrunner/README.md) supports **bbCode** and **Jinteki** formats.
 
 The [One Piece plugin](plugins/one_piece/README.md) supports **Egman Events** and **OPTCG Simulator** formats.
 

--- a/hugo/content/plugins/_index.md
+++ b/hugo/content/plugins/_index.md
@@ -22,7 +22,7 @@ The following plugins are currently available:
 * [Grand Archive](grand_archive)
 * [Gundam](gundam)
 * [Lorcana](lorcana)
-* [Netrunner](netrunner)
+* [Android: Netrunner](netrunner)
 * [One Piece](one_piece)
 * [Riftbound](riftbound)
 * [Sorcery: Contested Realm](sorcery_contested_realm)

--- a/hugo/content/plugins/netrunner.md
+++ b/hugo/content/plugins/netrunner.md
@@ -1,5 +1,5 @@
 ---
-title: 'Netrunner'
+title: 'Android: Netrunner'
 weight: 80
 ---
 

--- a/plugins/netrunner/README.md
+++ b/plugins/netrunner/README.md
@@ -1,4 +1,4 @@
-# Netrunner Plugin
+# Android: Netrunner Plugin
 
 This plugin reads a decklist, fetches the card images from [NRO Proxy](https://proxy.nro.run/), and puts the card images into the proper `game/` directories.
 


### PR DESCRIPTION
Closes #142

Renames the user-facing display name of the Netrunner plugin to **Android: Netrunner** (the full official game name) across docs and plugin metadata. Matches the colon-subtitle convention already used for "Magic: The Gathering" and "Sorcery: Contested Realm" elsewhere in the same plugins list.

## What this PR intentionally does NOT do

- Does not rename the directory `plugins/netrunner/` — CLI users invoke `python plugins/netrunner/fetch.py`, and the slug is also the Hugo URL path. A directory rename would break invocation, internal imports, and any inbound links.
- Does not rename `NETRUNNERDB_SET_URL_TEMPLATE` / `NETRUNNERDB_URL_TEMPLATE` — those reference the `netrunnerdb.com` API, not the game name.
- Does not rename `TestNetrunnerAPI` / `test/test_netrunner_plugin.py` — internal names that don't affect users.

If you'd prefer a fuller rename (directory, slug, internal names), happy to do that in a follow-up; I started here because every other change is reversible and risk-free.

## Testing

- `git diff --stat` shows only 5 single-line changes across docs/markdown.
- No code paths touched; existing CLI command `python plugins/netrunner/fetch.py game/decklist/deck.txt text` is unchanged.
- Hugo URL path `/plugins/netrunner/` is unchanged; only the rendered title changes.