### PR TITLE
fix(star_wars_unlimited): rotate landscape cards clockwise to match MTG/Bushiroad

### DIFF
--- a/plugins/star_wars_unlimited/swudb.py
+++ b/plugins/star_wars_unlimited/swudb.py
@@ -93,7 +93,7 @@ def fetch_card(
             # Align the rotated art so that it has the correct orientation
             front_image_for_rotation = Image.open(front_image_path)
             if front_image_for_rotation.height < front_image_for_rotation.width:
-                front_image_rotated = front_image_for_rotation.rotate(90, expand=True)
+                front_image_rotated = front_image_for_rotation.rotate(-90, expand=True)
                 front_image_rotated.save(front_image_path)
 
         if back_art != None:
@@ -105,7 +105,7 @@ def fetch_card(
             # Align the rotated art so that it has the correct orientation
             back_image_for_rotation = Image.open(back_image_path)
             if back_image_for_rotation.height < back_image_for_rotation.width:
-                back_image_rotated = back_image_for_rotation.rotate(90, expand=True)
+                back_image_rotated = back_image_for_rotation.rotate(-90, expand=True)
                 back_image_rotated.save(back_image_path)
 
 def get_handle_card(


### PR DESCRIPTION
## Summary

Fix the landscape-to-portrait rotation in `plugins/star_wars_unlimited/swudb.py` so it spins clockwise (`-90`) like Bushiroad and MTG, instead of counter-clockwise (`+90`).

## Why this matters

Issue #149 documents that the project's plugins disagree on which way to rotate landscape cards into portrait orientation. MTG (the model plugin per `plugins/mtg/scryfall.py:123`) and Bushiroad (`plugins/bushiroad/bushiroad.py:75`) use `rotate(-90, ...)`, which puts the top of the landscape card on the right side of the portrait. Star Wars Unlimited goes the other way, so SWU bases and leaders come out flipped relative to the rest of the deck. The result is visible inconsistency on a printed sheet whenever a deck mixes plugins or a user re-renders the same deck across plugins.

The issue also lists LOTR LCG as needing the same fix, but that plugin is no longer present in the tree (`plugins/` has no `lotr_lcg/` directory and `git log --all` shows no historical `ringsdb.py`). So this PR scopes to SWU only and the LOTR LCG bullet of the issue can stay open or be removed by a maintainer who has the history.

## Changes

`plugins/star_wars_unlimited/swudb.py`: changes the two `rotate(90, expand=True)` calls (front image at line 96 and back image at line 108) to `rotate(-90, expand=True)`. `expand=True` is preserved on both lines and the surrounding `if image.height < image.width:` guard is unchanged.

## Testing

No automated tests are present in this repo for plugin rotation. Manual verification: run `grep "rotate" plugins/star_wars_unlimited/swudb.py` after the change and confirm the only landscape-to-portrait rotations are `-90`, matching the values used by `plugins/mtg/scryfall.py` and `plugins/bushiroad/bushiroad.py`.

For end-to-end visual confirmation, the issue suggests:

```sh
python plugins/star_wars_unlimited/fetch.py <test_deck_url> swudb
```

with a deck that contains landscape cards (bases / leaders), and visually compare against an MTG render of similar landscape cards.

Fixes #149 (SWU portion only; LOTR LCG plugin is not present in the current tree)
