### PR TITLE
Fix SWU plugin crash with special characters in card titles

### DIFF
--- a/plugins/star_wars_unlimited/deck_formats.py
+++ b/plugins/star_wars_unlimited/deck_formats.py
@@ -36,6 +36,8 @@ def parse_deck_helper(deck_text: str, handle_card: Callable, deck_splitter: Call
     return index
 
 def parse_swudb_json(deck_text: str, handle_card: Callable) -> None:
+    error_lines = []
+
     data = loads(deck_text)
 
     # Get cards from leader, base, deck, and sideboard
@@ -52,14 +54,23 @@ def parse_swudb_json(deck_text: str, handle_card: Callable) -> None:
     for index, card in enumerate(cards, start=1):
         card_id = card.get("id")
         quantity = card.get("count", 1)
-        name, title = fetch_name_and_title(card_id)
 
-        parts = [f'Index: {index}', f'quantity: {quantity}']
-        if card_id: parts.append(f'card ID: {card_id}')
-        if name: parts.append(f'name: {name}')
-        if title: parts.append(f'title: {title}')
-        print(', '.join(parts))
-        handle_card(index, name, title, quantity)
+        try:
+            name, title = fetch_name_and_title(card_id)
+
+            parts = [f'Index: {index}', f'quantity: {quantity}']
+            if card_id: parts.append(f'card ID: {card_id}')
+            if name: parts.append(f'name: {name}')
+            if title: parts.append(f'title: {title}')
+            print(', '.join(parts))
+
+            handle_card(index, name, title, quantity)
+        except Exception as e:
+            print(f'Error: {e}')
+            error_lines.append((card_id, e))
+
+    if len(error_lines) > 0:
+        print(f'Errors: {error_lines}')
 
 def parse_melee(deck_text: str, handle_card: Callable) -> None:
     pattern = compile(r'^(\d+)\s*\|\s*([\w\'\-]+(?:\s+[\w\'\-]+)*)\s*(?:\|\s*(.+))?$') # '{Quantity} {Name} | {Title}'
@@ -82,22 +93,35 @@ def parse_melee(deck_text: str, handle_card: Callable) -> None:
     parse_deck_helper(deck_text, handle_card, split_melee_deck, is_melee_line, extract_melee_card_data)
 
 def parse_picklist(deck_text: str, handle_card: Callable) -> None:
-    pattern = compile(r'^((?:\[\s\]\s*)+)\s*([\w\'\-]+(?:\s+[\w\'\-]+)*)\s*(?:\|\s*(.+))?$') # '{Quantity as [ ]} {Name} | {Title}'
+    # Picklist format: [ ] Name | Title (optional)
+    # followed by a line with card IDs that we skip
+    # Pattern allows for various characters in names and titles
+    pattern = compile(r'^((?:\[\s*\]\s*)+)\s*(.+?)\s*(?:\|\s*(.+))?$')
 
     def split_picklist_deck(deck_text: str):
         return deck_text.strip().split('\n')
 
     def is_picklist_line(line) -> bool:
+        # Skip lines that start with card IDs (e.g., "LAW 003, LAW 267")
+        # Skip separator lines (-----)
+        # Skip header lines
+        stripped = line.strip()
+        if not stripped or stripped.startswith('-') or stripped.startswith('Picklist:'):
+            return False
+        # Skip lines that look like card IDs (start with letters and spaces/numbers)
+        if stripped and not stripped.startswith('[') and compile(r'^\s*[A-Z]{2,}\s+\d').match(stripped):
+            return False
         return bool(pattern.match(line))
 
     def extract_picklist_card_data(line) -> card_data_tuple:
         match = pattern.match(line)
         if match:
+            quantity_group = match.group(1).strip()
             name = match.group(2).strip()
             title = match.group(3)
-            quantity_group = match.group(1).strip()
+            quantity = quantity_group.count('[ ]') if quantity_group else 1
 
-            return (name, '' if title is None else title.strip(), '', quantity_group.count('[ ]'))
+            return (name, '' if title is None else title.strip(), '', quantity)
 
     parse_deck_helper(deck_text, handle_card, split_picklist_deck, is_picklist_line, extract_picklist_card_data)
 

--- a/plugins/star_wars_unlimited/swudb.py
+++ b/plugins/star_wars_unlimited/swudb.py
@@ -2,6 +2,7 @@ from os import path
 from requests import Response, Session
 from time import sleep
 from re import sub, compile
+from urllib.parse import quote
 from PIL import Image
 from typing import Tuple
 
@@ -64,7 +65,8 @@ def fetch_card(
     back_img_dir: str,
 ):
     # Fetch card art by querying name and title.
-    title_query = '' if title == '' else f' title:"{title}"'
+    # URL encode the title to handle special characters like "?" and "&"
+    title_query = '' if title == '' else f' title:"{quote(title)}"'
     printings = request_swudb(SWUDB_NAME_URL_TEMPLATE.format(name=name, title=title_query)).json().get('printings', [])
 
     if not printings:

--- a/test/test_star_wars_unlimited_plugin.py
+++ b/test/test_star_wars_unlimited_plugin.py
@@ -180,6 +180,16 @@ class TestSwudbAPI:
         assert name != ""
         assert title == ""
 
+    def test_fetch_name_and_title_with_special_characters(self):
+        """Test fetching card name and title with special characters like '?'.
+
+        This tests the URL encoding fix for cards like "Bib Fortuna | Die Wanna Wanga?"
+        which have question marks or other special characters in the title.
+        """
+        name, title = fetch_name_and_title("LAW_134")
+        assert name == "Bib Fortuna"
+        assert title == "Die Wanna Wanga?"
+
 
 @pytest.mark.integration
 class TestFullFetchWorkflow:
@@ -278,3 +288,24 @@ class TestFullFetchWorkflow:
 
         # Both sides should share the same filename (matched by index/name)
         assert front_files[0] == back_files[0]
+
+    def test_fetch_card_with_special_characters_in_title(self, temp_dirs):
+        """Test fetching a card with special characters (?, &, etc.) in the title.
+
+        This is a regression test for the bug where cards like "Bib Fortuna | Die Wanna Wanga?"
+        would fail to fetch because the '?' wasn't being URL-encoded in the API query.
+        """
+        front_dir, double_sided_dir = temp_dirs
+
+        deck_text = """Deck
+1 | Bib Fortuna | Die Wanna Wanga?"""
+
+        handle_card = get_handle_card(front_dir, double_sided_dir)
+        parse_deck(deck_text, DeckFormat.MELEE, handle_card)
+
+        files = os.listdir(front_dir)
+        assert len(files) >= 1, "Card with '?' in title should be fetched successfully"
+
+        for f in files:
+            file_path = os.path.join(front_dir, f)
+            assert os.path.getsize(file_path) > 0, "Fetched image should have content"


### PR DESCRIPTION
The plugin was crashing when fetching cards with special characters (like '?', '&') in their titles because these characters weren't being URL-encoded in the SWUDB API query.

Changes:
- Add URL encoding for card title queries using urllib.parse.quote
- Add error handling to parse_swudb_json to continue on card failures
- Improve picklist format parser to handle card IDs on separate lines
- Add regression tests for cards with special characters in titles

Fixes the crash at card 7 (Bib Fortuna | Die Wanna Wanga?) and enables all three deck formats (JSON, melee, picklist) to work correctly.