### PR TITLE
Documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ It's pivotal to ensure that your card fronts and backs are aligned. The front an
 
 First, you must determine the offset by using the [calibration sheets](calibration/).
 
-`<paper size>_calibration.pdf` has a front page and a back page.
+`<paper size>-calibration.pdf` has a front page and a back page.
 
 ![Calibration](hugo/static/images/calibration.png)
 
@@ -372,7 +372,7 @@ The back page is the same grid of squares, except each square has a slight offse
 | (-2, -2) | (-1, -2) | ( 0, -2) | ( 1, -2) | ( 2, -2) |
 ```
 
-To determine the required offset, print out `<paper size>_calibration.pdf` with the card stock you plan to use.
+To determine the required offset, print out `<paper size>-calibration.pdf` with the card stock you plan to use.
 
 Shine a strong light on the front so you can see the shadows on the back. Determine which set of front and back squares are aligned. This set will provide your offset.
 
@@ -397,10 +397,10 @@ If no square on your calibration sheet matches, then you'll need to create a new
 To create an offset calibration sheet, use the `--pdf_path` option, targeting the calibration sheet of your paper size. For example:
 
 ```sh
-python offset_pdf.py --pdf_path calibration/letter_calibration.pdf --x_offset 30 --y_offset -10
+python offset_pdf.py --pdf_path calibration/letter-calibration.pdf --x_offset 30 --y_offset -10
 ```
 
-This will produce `calibration/letter_calibration_offset.pdf`, which is the same as calibration sheet but with an offset of (30, -10).
+This will produce `calibration/letter-calibration_offset.pdf`, which is the same as calibration sheet but with an offset of (30, -10).
 
 Print this out and determine which set of front and back squares are aligned. If none are aligned, try generating another offset calibration sheet with a different arbitrary offset.
 
@@ -412,10 +412,10 @@ Let's say there is a set of a front and back squares and the offset is (5, 5). Y
 
 The true offset if (35, -5).
 
-You can verify this is true by generating a offset calibration sheet using this offset.
+You can verify this is true by generating an offset calibration sheet using this offset.
 
 ```sh
-python offset_pdf.py --pdf_path calibration/letter_calibration.pdf --x_offset 35 --y_offset -5
+python offset_pdf.py --pdf_path calibration/letter-calibration.pdf --x_offset 35 --y_offset -5
 ```
 
 Print this out and the center set of front and back squares, (0, 0), should be aligned.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ python create_pdf.py --paper_size a4
 
 Get your PDF at `game/output/game.pdf`.
 
+**Note:** When printing the PDF with duplex printing (double-sided), use **long side flip** (flip on long edge) to ensure proper front and back alignment.
+
 ### Double-Sided Cards
 
 To create double-sided cards, put front images in the `game/front/` folder and back images in the `game/double_sided/` folder. The filenames (and file extensions) must match for each pair.

--- a/hugo/content/docs/create.md
+++ b/hugo/content/docs/create.md
@@ -67,6 +67,9 @@ python create_pdf.py --paper_size a4
 
 Get your PDF at `game/output/game.pdf`.
 
+> [!IMPORTANT]
+> When printing the PDF with duplex printing (double-sided), use **long side flip** (flip on long edge) to ensure proper front and back alignment.
+
 ## Plugins
 
 Plugins streamline the process for acquiring card images for various games.

--- a/hugo/content/docs/offset.md
+++ b/hugo/content/docs/offset.md
@@ -11,7 +11,7 @@ It's pivotal to ensure that your card fronts and backs are aligned. The front an
 
 First, you must determine the offset by using the [calibration sheets](https://github.com/Alan-Cha/silhouette-card-maker/tree/main/calibration).
 
-`<paper size>_calibration.pdf` has a front page and a back page.
+`<paper size>-calibration.pdf` has a front page and a back page.
 
 ![Calibration](/images/calibration.png)
 
@@ -31,7 +31,7 @@ The back page is the same grid of squares, except each square has a slight offse
 | (-2, -2) | (-1, -2) | ( 0, -2) | ( 1, -2) | ( 2, -2) |
 ```
 
-To determine the required offset, print out `<paper size>_calibration.pdf` with the card stock you plan to use.
+To determine the required offset, print out `<paper size>-calibration.pdf` with the card stock you plan to use.
 
 Shine a strong light on the front so you can see the shadows on the back. Determine which set of front and back squares are aligned. This set will provide your offset.
 
@@ -56,10 +56,10 @@ If no square on your calibration sheet matches, then you'll need to create a new
 To create an offset calibration sheet, use the `--pdf_path` option, targeting the calibration sheet of your paper size. For example:
 
 ```sh
-python offset_pdf.py --pdf_path calibration/letter_calibration.pdf --x_offset 30 --y_offset -10
+python offset_pdf.py --pdf_path calibration/letter-calibration.pdf --x_offset 30 --y_offset -10
 ```
 
-This will produce `calibration/letter_calibration_offset.pdf`, which is the same as calibration sheet but with an offset of (30, -10).
+This will produce `calibration/letter-calibration_offset.pdf`, which is the same as calibration sheet but with an offset of (30, -10).
 
 Print this out and determine which set of front and back squares are aligned. If none are aligned, try generating another offset calibration sheet with a different arbitrary offset.
 
@@ -71,10 +71,10 @@ Let's say there is a set of a front and back squares and the offset is (5, 5). Y
 
 The true offset if (35, -5).
 
-You can verify this is true by generating a offset calibration sheet using this offset.
+You can verify this is true by generating an offset calibration sheet using this offset.
 
 ```sh
-python offset_pdf.py --pdf_path calibration/letter_calibration.pdf --x_offset 35 --y_offset -5
+python offset_pdf.py --pdf_path calibration/letter-calibration.pdf --x_offset 35 --y_offset -5
 ```
 
 Print this out and the center set of front and back squares, (0, 0), should be aligned.

--- a/hugo/content/tutorial/guide.md
+++ b/hugo/content/tutorial/guide.md
@@ -223,6 +223,9 @@ You can find the PDF in `game/output/game.pdf` and it should look similar to the
 
 Print the PDF with `actual size` scale. Ensure the print **exactly matches** the PDF and pay close attention to the white margins. If the print does not match, your cards will be the wrong size or registration will fail entirely.
 
+> [!IMPORTANT]
+> If you're using duplex printing (double-sided printing), make sure to use **long side flip** (also called "flip on long edge"). This ensures the backs align correctly with the fronts.
+
 ![Print](/images/lamination.jpg)
 
 Laminate the sheets. Because cardstock is thicker than printer paper, you may need to use a **higher setting** on your laminator. If not, you could have cloudy lamination or delamination issues.


### PR DESCRIPTION
## Summary
- Fix calibration filename references (underscore → hyphen)
- Add duplex printing instructions

## Changes
1. Corrected all references from `letter_calibration.pdf` to `letter-calibration.pdf` and `<paper size>_calibration.pdf` to `<paper size>-calibration.pdf` to match actual filenames
2. Fixed grammar error "a offset" → "an offset"
3. Added documentation specifying that PDFs should be printed using **long side flip** (flip on long edge) when using duplex printing for proper front and back alignment

## Files Modified
- README.md
- hugo/content/docs/create.md
- hugo/content/docs/offset.md
- hugo/content/tutorial/guide.md