### PR TITLE
Refactor fetch_card() and fetch_card_art() in the MTG plugin (#86)

### DIFF
--- a/plugins/mtg/scryfall.py
+++ b/plugins/mtg/scryfall.py
@@ -162,21 +162,36 @@ def fetch_card_art(
     quantity: int,
 
     clean_card_name: str,
-    card_set: int,
-    card_collector_number: int,
+    card_set: str,
+    card_collector_number: str,
+    output_dir: str,
+
+    prefer_langs: List[ScryfallLanguage] = None,
+    face: str = None,
+) -> None:
+    card_art = fetch_image(card_set, card_collector_number, prefer_langs, face=face)
+    if card_art is not None:
+        save_card_art_copies(card_art, output_dir, index, clean_card_name, quantity)
+
+def fetch_card_faces(
+    index: int,
+    quantity: int,
+
+    clean_card_name: str,
+    card_set: str,
+    card_collector_number: str,
     layout: str,
 
-    all_parts: List = None,
-    card_name: str = None,
     prefer_langs: List[ScryfallLanguage] = None,
 
     front_img_dir: str = None,
     double_sided_dir: str = None,
+
+    all_parts: List = None,
+    card_name: str = None,
 ) -> None:
-    # Query for the front side
-    card_art = fetch_image(card_set, card_collector_number, prefer_langs)
-    if card_art is not None:
-        save_card_art_copies(card_art, front_img_dir, index, clean_card_name, quantity)
+    # Front face
+    fetch_card_art(index, quantity, clean_card_name, card_set, card_collector_number, front_img_dir, prefer_langs)
 
     # Get backside of card, if it exists
     if layout in double_sided_layouts:
@@ -184,9 +199,7 @@ def fetch_card_art(
             if all_parts and card_name:
                 fetch_meld_back(index, quantity, clean_card_name, card_name, all_parts, double_sided_dir)
         else:
-            card_art = fetch_image(card_set, card_collector_number, prefer_langs, face='back')
-            if card_art is not None:
-                save_card_art_copies(card_art, double_sided_dir, index, clean_card_name, quantity)
+            fetch_card_art(index, quantity, clean_card_name, card_set, card_collector_number, double_sided_dir, prefer_langs, face='back')
 
 def partition_printings(printings: List, condition: List) -> Tuple[List, List]:
     matches = []
@@ -248,18 +261,18 @@ def fetch_card(
         # Query for card info
         card_json = request_scryfall(card_info_query).json()
 
-        fetch_card_art(
+        fetch_card_faces(
             index,
             quantity,
             remove_nonalphanumeric(card_json['name']),
             card_json['set'],
             card_json['collector_number'],
             card_json['layout'],
-            card_json.get('all_parts'),
-            card_json['name'],
             prefer_langs,
             front_img_dir,
             double_sided_dir,
+            card_json.get('all_parts'),
+            card_json['name'],
         )
 
         # Fetch tokens
@@ -269,7 +282,7 @@ def fetch_card(
                     if related["component"] == "token":
                         card_info_query = related["uri"]
                         card_json = request_scryfall(card_info_query).json()
-                        fetch_card_art(
+                        fetch_card_faces(
                             index,
                             quantity,
                             # Offsprint tokens have the same name as the card, so append _token to differentiate
@@ -346,18 +359,18 @@ def fetch_card(
                 set = best_print["set"]
                 collector_number = best_print["collector_number"]
 
-        fetch_card_art(
+        fetch_card_faces(
             index,
             quantity,
             clean_card_name,
             set,
             collector_number,
             card_json['layout'],
-            card_json.get('all_parts'),
-            card_json['name'],
             prefer_langs,
             front_img_dir,
             double_sided_dir,
+            card_json.get('all_parts'),
+            card_json['name'],
         )
 
         # Fetch tokens
@@ -367,7 +380,7 @@ def fetch_card(
                     if related["component"] == "token":
                         card_info_query = related["uri"]
                         card_json = request_scryfall(card_info_query).json()
-                        fetch_card_art(
+                        fetch_card_faces(
                             index,
                             quantity,
                             # Offsprint tokens have the same name as the card, so append _token to differentiate

--- a/test/test_mtg_plugin.py
+++ b/test/test_mtg_plugin.py
@@ -7,7 +7,7 @@ import shutil
 import tempfile
 import pytest
 import requests
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 from plugins.mtg.deck_formats import (
     DeckFormat,
@@ -21,7 +21,7 @@ from plugins.mtg.deck_formats import (
     parse_scryfall_json,
 )
 from plugins.mtg.common import ScryfallLanguage, to_scryfall_api_lang
-from plugins.mtg.scryfall import request_scryfall, get_handle_card, fetch_card, fetch_printings, build_image_url, fetch_image
+from plugins.mtg.scryfall import request_scryfall, get_handle_card, fetch_card, fetch_card_faces, fetch_printings, build_image_url, fetch_image
 from typing import List
 from plugins.mtg.patterns import MOXFIELD_PATTERN, DECKSTATS_PATTERN
 
@@ -840,7 +840,7 @@ class TestFetchCardWithLanguage:
                    front_img_dir='front', double_sided_dir='double_sided')
 
         args, _ = mock_fetch_art.call_args
-        assert args[8] == langs
+        assert args[6] == langs
 
     @patch('plugins.mtg.scryfall.fetch_card_art')
     @patch('plugins.mtg.scryfall.request_scryfall')
@@ -854,7 +854,74 @@ class TestFetchCardWithLanguage:
                    front_img_dir='front', double_sided_dir='double_sided')
 
         args, _ = mock_fetch_art.call_args
-        assert args[8] is None
+        assert args[6] is None
+
+
+class TestFetchCardFaces:
+    """Unit tests for fetch_card_faces, which owns the front/back (double-faced
+    and meld) decision logic that fetch_card_art used to contain."""
+
+    @patch('plugins.mtg.scryfall.fetch_meld_back')
+    @patch('plugins.mtg.scryfall.fetch_card_art')
+    def test_normal_layout_fetches_front_only(self, mock_art, mock_meld):
+        """A single-faced card only fetches its front art."""
+        fetch_card_faces(1, 1, 'lightningbolt', 'lea', '161', 'normal',
+                         prefer_langs=None, front_img_dir='F', double_sided_dir='D')
+
+        mock_art.assert_called_once_with(1, 1, 'lightningbolt', 'lea', '161', 'F', None)
+        mock_meld.assert_not_called()
+
+    @patch('plugins.mtg.scryfall.fetch_meld_back')
+    @patch('plugins.mtg.scryfall.fetch_card_art')
+    def test_double_faced_layout_fetches_front_and_back(self, mock_art, mock_meld):
+        """A double-faced card fetches the front into front_img_dir and the
+        back (face='back') into double_sided_dir."""
+        fetch_card_faces(2, 1, 'valki', 'khm', '111', 'modal_dfc',
+                         prefer_langs=None, front_img_dir='F', double_sided_dir='D')
+
+        assert mock_art.call_args_list == [
+            call(2, 1, 'valki', 'khm', '111', 'F', None),
+            call(2, 1, 'valki', 'khm', '111', 'D', None, face='back'),
+        ]
+        mock_meld.assert_not_called()
+
+    @patch('plugins.mtg.scryfall.fetch_meld_back')
+    @patch('plugins.mtg.scryfall.fetch_card_art')
+    def test_meld_layout_uses_fetch_meld_back(self, mock_art, mock_meld):
+        """A meld card fetches the front normally but delegates the back to
+        fetch_meld_back rather than requesting a 'back' face."""
+        all_parts = [{'component': 'meld_result', 'name': 'Urza, Planeswalker'}]
+        fetch_card_faces(3, 1, 'urzalordhighartificer', 'bro', '225', 'meld',
+                         prefer_langs=None, front_img_dir='F', double_sided_dir='D',
+                         all_parts=all_parts, card_name='Urza, Lord High Artificer')
+
+        mock_art.assert_called_once_with(3, 1, 'urzalordhighartificer', 'bro', '225', 'F', None)
+        mock_meld.assert_called_once_with(
+            3, 1, 'urzalordhighartificer', 'Urza, Lord High Artificer', all_parts, 'D')
+
+    @patch('plugins.mtg.scryfall.fetch_meld_back')
+    @patch('plugins.mtg.scryfall.fetch_card_art')
+    def test_meld_layout_without_parts_skips_back(self, mock_art, mock_meld):
+        """A meld layout missing all_parts/card_name fetches only the front and
+        does not attempt the meld back."""
+        fetch_card_faces(4, 1, 'somecard', 'bro', '1', 'meld',
+                         prefer_langs=None, front_img_dir='F', double_sided_dir='D')
+
+        mock_art.assert_called_once_with(4, 1, 'somecard', 'bro', '1', 'F', None)
+        mock_meld.assert_not_called()
+
+    @patch('plugins.mtg.scryfall.fetch_meld_back')
+    @patch('plugins.mtg.scryfall.fetch_card_art')
+    def test_quantity_and_langs_passed_through(self, mock_art, mock_meld):
+        """quantity and prefer_langs are forwarded to fetch_card_art for both faces."""
+        langs = [ScryfallLanguage.JAPANESE]
+        fetch_card_faces(5, 3, 'card', 'set', '7', 'transform',
+                         prefer_langs=langs, front_img_dir='F', double_sided_dir='D')
+
+        assert mock_art.call_args_list == [
+            call(5, 3, 'card', 'set', '7', 'F', langs),
+            call(5, 3, 'card', 'set', '7', 'D', langs, face='back'),
+        ]
 
 
 # --- Integration Tests for API and Image Fetching ---


### PR DESCRIPTION
Closes #86.

Splits the two functions' responsibilities:

- `fetch_card_art()` now does one thing: fetch a single card face's art and save it to one directory. It no longer knows about backs, double-faced layouts, or meld. 

- The double-faced/meld decision logic that used to live inside `fetch_card_art()` now lives in a new `fetch_card_faces()` helper, which `fetch_card()` calls for both the main card and each related token. It fetches the front via `fetch_card_art`, and only for `double_sided_layouts` fetches the back (`face='back'`, or `fetch_meld_back` for meld).

- Also corrected the card_set/card_collector_number type hints from int to str to match fetch_image

Couple of notes:

- Left the per-quantity saving inside `fetch_card_art()`, where the image bytes already are, so that function stays self-contained and easy to test, but down to move it up

- Behavior is unchanged for normal, double-faced, and meld layouts. Added a (mostly opus-generated) `TestFetchCardFaces` class covering those paths (front-only, front+back, meld delegation, the meld no-parts guard, and quantity/langs passthrough). 

Tested with: `python -m pytest test/test_mtg_plugin.py -m "not integration"`
(49 passed).