### PR TITLE
Support assets/layouts-extra.json for extending card sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,8 @@ test/*/output/*
 cutting_templates/dxf/
 cutting_templates/borderless/dxf/
 
+assets/extra_layouts/*
+!assets/extra_layouts/README.md
+
 hugo/public/
 .vscode/launch.json

--- a/assets/extra_layouts/README.md
+++ b/assets/extra_layouts/README.md
@@ -1,0 +1,7 @@
+# extra_layouts
+
+Drop any number of `*.json` files here to extend `layouts.json` with additional card sizes,
+paper sizes, and layouts, without modifying this repo. Files are merged in filename order;
+see `merge_extra_layouts()` in `utilities.py` for the merge rules.
+
+This directory is empty by default — nothing here changes behavior until you add a file.

--- a/assets/extra_layouts/README.md
+++ b/assets/extra_layouts/README.md
@@ -1,7 +1,9 @@
-# extra_layouts
+# Extra Layouts
 
 Drop any number of `*.json` files here to extend `layouts.json` with additional card sizes,
 paper sizes, and layouts, without modifying this repo. Files are merged in filename order;
 see `merge_extra_layouts()` in `utilities.py` for the merge rules.
 
-This directory is empty by default — nothing here changes behavior until you add a file.
+This directory is empty by default — nothing here changes behavior until you add a file. For
+an example of a project that defines its own card sizes this way, see
+[scm-extras](https://github.com/Alan-Cha/scm-extras).

--- a/dxf_to_studio3.py
+++ b/dxf_to_studio3.py
@@ -38,7 +38,7 @@ import platform
 import click
 
 from enums import Orientation, Variant, Unit
-from utilities import load_layout_config, get_all_paper_size_names, resolve_paper_size_alias, LayoutConfig, template_name, resolve_output_dir, BORDERLESS_EXPANSION_MM
+from utilities import load_layout_config, get_all_paper_size_names, resolve_paper_size_alias, LayoutConfig, template_name, resolve_cutting_templates_dir, BORDERLESS_EXPANSION_MM
 import size_convert
 import page_manager
 
@@ -85,7 +85,7 @@ ASSETS_DIR = Path(__file__).parent / "assets"
 CALIBRATION_FILE = ASSETS_DIR / "gui_coordinates.json"
 
 # Batch conversion defaults
-TEMPLATES_DIR = resolve_output_dir(Path(__file__).parent / "cutting_templates")
+TEMPLATES_DIR = resolve_cutting_templates_dir(Path(__file__).parent / "cutting_templates")
 
 
 

--- a/dxf_to_studio3.py
+++ b/dxf_to_studio3.py
@@ -38,7 +38,7 @@ import platform
 import click
 
 from enums import Orientation, Variant, Unit
-from utilities import load_layout_config, get_all_paper_size_names, resolve_paper_size_alias, LayoutConfig, template_name, BORDERLESS_EXPANSION_MM
+from utilities import load_layout_config, get_all_paper_size_names, resolve_paper_size_alias, LayoutConfig, template_name, resolve_output_dir, BORDERLESS_EXPANSION_MM
 import size_convert
 import page_manager
 
@@ -85,7 +85,7 @@ ASSETS_DIR = Path(__file__).parent / "assets"
 CALIBRATION_FILE = ASSETS_DIR / "gui_coordinates.json"
 
 # Batch conversion defaults
-TEMPLATES_DIR = Path(__file__).parent / "cutting_templates"
+TEMPLATES_DIR = resolve_output_dir(Path(__file__).parent / "cutting_templates")
 
 
 

--- a/generate_dxf.py
+++ b/generate_dxf.py
@@ -21,7 +21,6 @@ Usage:
 """
 
 import json
-import os
 from pathlib import Path
 
 import click
@@ -30,10 +29,10 @@ import page_manager
 import dxf_manager
 import size_convert
 from enums import Orientation, OrientationMode, Variant
-from utilities import LayoutConfig, load_layout_config, template_name, resolve_card_size_alias, resolve_paper_size_alias, get_all_card_size_names, get_all_paper_size_names, find_best_orientation, resolve_output_dir, EXTRA_LAYOUTS_ENV, BORDERLESS_INSET_MM, BORDERLESS_EXPANSION_MM
+from utilities import LayoutConfig, load_layout_config, template_name, resolve_card_size_alias, resolve_paper_size_alias, get_all_card_size_names, get_all_paper_size_names, find_best_orientation, resolve_cutting_templates_dir, extra_layout_paths, BORDERLESS_INSET_MM, BORDERLESS_EXPANSION_MM
 
 SCRIPT_DIR = Path(__file__).parent
-CUTTING_TEMPLATES_DIR = resolve_output_dir(SCRIPT_DIR / "cutting_templates")
+CUTTING_TEMPLATES_DIR = resolve_cutting_templates_dir(SCRIPT_DIR / "cutting_templates")
 OUTPUT_DIR = CUTTING_TEMPLATES_DIR / "dxf"
 LAYOUTS_PATH = SCRIPT_DIR / "assets" / "layouts.json"
 
@@ -277,10 +276,11 @@ def single(output_file, paper_size, card_size, card_height, card_width, card_rad
     print(f"  {paper_label} + {card_label} ({variant}): {num_cols}x{num_rows} ({num_cards} cards), max_length={computed.max_length_mm}mm -> {output_path}")
 
     if save:
-        # If EXTRA_LAYOUTS_ENV is configured, new entries go to the last file in its list
-        # instead of this repo's own layouts.json, so opt-in extra sizes stay out of it.
-        extra_paths = [p for p in os.environ.get(EXTRA_LAYOUTS_ENV, '').split(os.pathsep) if p]
-        save_path = Path(extra_paths[-1]) if extra_paths else LAYOUTS_PATH
+        # If any extra layout files are configured (drop-in directory and/or env var), new
+        # entries go to the last one instead of this repo's own layouts.json, so opt-in extra
+        # sizes stay out of it.
+        extra_paths = extra_layout_paths()
+        save_path = extra_paths[-1] if extra_paths else LAYOUTS_PATH
 
         if save_path.exists():
             with open(save_path, 'r') as f:

--- a/generate_dxf.py
+++ b/generate_dxf.py
@@ -21,6 +21,7 @@ Usage:
 """
 
 import json
+import os
 from pathlib import Path
 
 import click
@@ -29,10 +30,11 @@ import page_manager
 import dxf_manager
 import size_convert
 from enums import Orientation, OrientationMode, Variant
-from utilities import LayoutConfig, load_layout_config, template_name, resolve_card_size_alias, resolve_paper_size_alias, get_all_card_size_names, get_all_paper_size_names, find_best_orientation, BORDERLESS_INSET_MM, BORDERLESS_EXPANSION_MM
+from utilities import LayoutConfig, load_layout_config, template_name, resolve_card_size_alias, resolve_paper_size_alias, get_all_card_size_names, get_all_paper_size_names, find_best_orientation, resolve_output_dir, EXTRA_LAYOUTS_ENV, BORDERLESS_INSET_MM, BORDERLESS_EXPANSION_MM
 
 SCRIPT_DIR = Path(__file__).parent
-OUTPUT_DIR = SCRIPT_DIR / "cutting_templates" / "dxf"
+CUTTING_TEMPLATES_DIR = resolve_output_dir(SCRIPT_DIR / "cutting_templates")
+OUTPUT_DIR = CUTTING_TEMPLATES_DIR / "dxf"
 LAYOUTS_PATH = SCRIPT_DIR / "assets" / "layouts.json"
 
 
@@ -275,12 +277,26 @@ def single(output_file, paper_size, card_size, card_height, card_width, card_rad
     print(f"  {paper_label} + {card_label} ({variant}): {num_cols}x{num_rows} ({num_cards} cards), max_length={computed.max_length_mm}mm -> {output_path}")
 
     if save:
-        with open(LAYOUTS_PATH, 'r') as f:
-            raw_config = json.load(f)
+        # If EXTRA_LAYOUTS_ENV is configured, new entries go to the last file in its list
+        # instead of this repo's own layouts.json, so opt-in extra sizes stay out of it.
+        extra_paths = [p for p in os.environ.get(EXTRA_LAYOUTS_ENV, '').split(os.pathsep) if p]
+        save_path = Path(extra_paths[-1]) if extra_paths else LAYOUTS_PATH
+
+        if save_path.exists():
+            with open(save_path, 'r') as f:
+                raw_config = json.load(f)
+        else:
+            raw_config = {}
+        raw_config.setdefault("card_sizes", {})
+        raw_config.setdefault("paper_sizes", {})
+        raw_config.setdefault("layouts", {})
 
         changed = False
 
-        if card_label not in raw_config["card_sizes"]:
+        # Existence checks use `config` (the already-merged view loaded at the top of this
+        # command) rather than raw_config, since raw_config may be just a delta file that
+        # doesn't redefine sizes already present in the base layouts.json or an earlier delta.
+        if card_label not in config.card_sizes:
             raw_config["card_sizes"][card_label] = {
                 "width": resolved_card_width,
                 "height": resolved_card_height,
@@ -289,7 +305,7 @@ def single(output_file, paper_size, card_size, card_height, card_width, card_rad
             print(f"  Saved new card size '{card_label}': {resolved_card_width} x {resolved_card_height}, radius {resolved_card_radius}")
             changed = True
 
-        if paper_label not in raw_config["paper_sizes"]:
+        if paper_label not in config.paper_sizes:
             raw_config["paper_sizes"][paper_label] = {
                 "width": resolved_paper_width,
                 "height": resolved_paper_height,
@@ -299,9 +315,9 @@ def single(output_file, paper_size, card_size, card_height, card_width, card_rad
 
         # Check if layout exists for this paper/card/variant combination
         layout_exists = (
-            paper_label in raw_config["layouts"]
-            and card_label in raw_config["layouts"].get(paper_label, {})
-            and variant in raw_config["layouts"][paper_label].get(card_label, {})
+            paper_label in config.layouts
+            and card_label in config.layouts.get(paper_label, {})
+            and variant in config.layouts[paper_label].get(card_label, {})
         )
 
         if not layout_exists:
@@ -320,7 +336,8 @@ def single(output_file, paper_size, card_size, card_height, card_width, card_rad
             changed = True
 
         if changed:
-            with open(LAYOUTS_PATH, 'w') as f:
+            save_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(save_path, 'w') as f:
                 json.dump(raw_config, f, indent=4)
                 f.write('\n')
         else:

--- a/generate_dxf.py
+++ b/generate_dxf.py
@@ -29,7 +29,7 @@ import page_manager
 import dxf_manager
 import size_convert
 from enums import Orientation, OrientationMode, Variant
-from utilities import LayoutConfig, load_layout_config, template_name, resolve_card_size_alias, resolve_paper_size_alias, get_all_card_size_names, get_all_paper_size_names, find_best_orientation, resolve_cutting_templates_dir, extra_layout_paths, BORDERLESS_INSET_MM, BORDERLESS_EXPANSION_MM
+from utilities import LayoutConfig, load_layout_config, template_name, resolve_card_size_alias, resolve_paper_size_alias, get_all_card_size_names, get_all_paper_size_names, find_best_orientation, resolve_cutting_templates_dir, extra_layout_paths, find_extra_layout_owner, BORDERLESS_INSET_MM, BORDERLESS_EXPANSION_MM
 
 SCRIPT_DIR = Path(__file__).parent
 CUTTING_TEMPLATES_DIR = resolve_cutting_templates_dir(SCRIPT_DIR / "cutting_templates")
@@ -276,11 +276,16 @@ def single(output_file, paper_size, card_size, card_height, card_width, card_rad
     print(f"  {paper_label} + {card_label} ({variant}): {num_cols}x{num_rows} ({num_cards} cards), max_length={computed.max_length_mm}mm -> {output_path}")
 
     if save:
-        # If any extra layout files are configured (drop-in directory and/or env var), new
-        # entries go to the last one instead of this repo's own layouts.json, so opt-in extra
-        # sizes stay out of it.
+        # Prefer the extra file that already defines this card size (or, failing that, this
+        # paper size), so a layout lands alongside the size it's for rather than an unrelated
+        # file when more than one extra layout file is in use. Falls back to the last extra
+        # file, then this repo's own layouts.json, so opt-in extra sizes stay out of it.
         extra_paths = extra_layout_paths()
-        save_path = extra_paths[-1] if extra_paths else LAYOUTS_PATH
+        save_path = (
+            find_extra_layout_owner('card_sizes', card_label)
+            or find_extra_layout_owner('paper_sizes', paper_label)
+            or (extra_paths[-1] if extra_paths else LAYOUTS_PATH)
+        )
 
         if save_path.exists():
             with open(save_path, 'r') as f:

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -1,3 +1,4 @@
+import json
 import math
 import os
 import tempfile
@@ -5,6 +6,7 @@ import pytest
 from pathlib import Path
 from PIL import Image
 
+import utilities
 from utilities import (
     parse_crop_string,
     convertInToCrop,
@@ -25,6 +27,8 @@ from utilities import (
     add_front_back_pages,
     FitMode,
     asset_directory,
+    merge_extra_layouts,
+    EXTRA_LAYOUTS_ENV,
 )
 from enums import Orientation
 
@@ -1574,6 +1578,151 @@ class TestDrawCardLayout:
         # Right: card ends at x=150, extends 15 pixels from x=150 to x=164
         assert base.getpixel((164, 50)) == self.RED
         assert base.getpixel((165, 50)) == self.WHITE
+
+
+class TestMergeExtraLayouts:
+    """Tests for merge_extra_layouts()."""
+
+    def base_config(self):
+        return {
+            "card_sizes": {"poker": {"width": "2.5in", "height": "3.5in"}},
+            "paper_sizes": {"letter": {"width": "11in", "height": "8.5in"}},
+            "layouts": {"letter": {"poker": {"default": {"orientation": "landscape", "version": 1}}}},
+        }
+
+    def write_extra_file(self, tmpdir, name, data):
+        path = Path(tmpdir) / name
+        with open(path, 'w') as f:
+            json.dump(data, f)
+        return str(path)
+
+    def test_no_env_var_is_noop(self):
+        os.environ.pop(EXTRA_LAYOUTS_ENV, None)
+        config = self.base_config()
+        result = merge_extra_layouts(config)
+        assert result == self.base_config()
+
+    def test_merges_new_card_size(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            extra_path = self.write_extra_file(tmpdir, "extra.json", {
+                "card_sizes": {"mtg": {"width": "2.5in", "height": "3.5in"}},
+            })
+            os.environ[EXTRA_LAYOUTS_ENV] = extra_path
+            try:
+                config = merge_extra_layouts(self.base_config())
+                assert config["card_sizes"]["mtg"] == {"width": "2.5in", "height": "3.5in"}
+                assert config["card_sizes"]["poker"] == {"width": "2.5in", "height": "3.5in"}
+            finally:
+                del os.environ[EXTRA_LAYOUTS_ENV]
+
+    def test_merges_new_layout_entry(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            extra_path = self.write_extra_file(tmpdir, "extra.json", {
+                "layouts": {"letter": {"mtg": {"default": {"orientation": "portrait", "version": 1}}}},
+            })
+            os.environ[EXTRA_LAYOUTS_ENV] = extra_path
+            try:
+                config = merge_extra_layouts(self.base_config())
+                assert config["layouts"]["letter"]["mtg"]["default"]["orientation"] == "portrait"
+                # Existing entry untouched
+                assert config["layouts"]["letter"]["poker"]["default"]["orientation"] == "landscape"
+            finally:
+                del os.environ[EXTRA_LAYOUTS_ENV]
+
+    def test_card_size_collision_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            extra_path = self.write_extra_file(tmpdir, "extra.json", {
+                "card_sizes": {"poker": {"width": "1in", "height": "1in"}},
+            })
+            os.environ[EXTRA_LAYOUTS_ENV] = extra_path
+            try:
+                with pytest.raises(ValueError):
+                    merge_extra_layouts(self.base_config())
+            finally:
+                del os.environ[EXTRA_LAYOUTS_ENV]
+
+    def test_layout_collision_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            extra_path = self.write_extra_file(tmpdir, "extra.json", {
+                "layouts": {"letter": {"poker": {"default": {"orientation": "portrait", "version": 1}}}},
+            })
+            os.environ[EXTRA_LAYOUTS_ENV] = extra_path
+            try:
+                with pytest.raises(ValueError):
+                    merge_extra_layouts(self.base_config())
+            finally:
+                del os.environ[EXTRA_LAYOUTS_ENV]
+
+    def test_multiple_files_merge_in_order(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path_a = self.write_extra_file(tmpdir, "a.json", {
+                "card_sizes": {"mtg": {"width": "2.5in", "height": "3.5in"}},
+            })
+            path_b = self.write_extra_file(tmpdir, "b.json", {
+                "card_sizes": {"sorcery": {"width": "2.61in", "height": "3.74in"}},
+            })
+            os.environ[EXTRA_LAYOUTS_ENV] = os.pathsep.join([path_a, path_b])
+            try:
+                config = merge_extra_layouts(self.base_config())
+                assert "mtg" in config["card_sizes"]
+                assert "sorcery" in config["card_sizes"]
+            finally:
+                del os.environ[EXTRA_LAYOUTS_ENV]
+
+    def test_scans_extra_layouts_dir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.write_extra_file(tmpdir, "a.json", {
+                "card_sizes": {"mtg": {"width": "2.5in", "height": "3.5in"}},
+            })
+            original_dir = utilities.EXTRA_LAYOUTS_DIR
+            utilities.EXTRA_LAYOUTS_DIR = Path(tmpdir)
+            try:
+                config = merge_extra_layouts(self.base_config())
+                assert config["card_sizes"]["mtg"] == {"width": "2.5in", "height": "3.5in"}
+            finally:
+                utilities.EXTRA_LAYOUTS_DIR = original_dir
+
+    def test_missing_extra_layouts_dir_is_noop(self):
+        os.environ.pop(EXTRA_LAYOUTS_ENV, None)
+        original_dir = utilities.EXTRA_LAYOUTS_DIR
+        utilities.EXTRA_LAYOUTS_DIR = Path(tempfile.gettempdir()) / "scm-test-nonexistent-dir"
+        try:
+            config = merge_extra_layouts(self.base_config())
+            assert config == self.base_config()
+        finally:
+            utilities.EXTRA_LAYOUTS_DIR = original_dir
+
+    def test_dir_file_collision_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.write_extra_file(tmpdir, "a.json", {
+                "card_sizes": {"poker": {"width": "1in", "height": "1in"}},
+            })
+            original_dir = utilities.EXTRA_LAYOUTS_DIR
+            utilities.EXTRA_LAYOUTS_DIR = Path(tmpdir)
+            try:
+                with pytest.raises(ValueError):
+                    merge_extra_layouts(self.base_config())
+            finally:
+                utilities.EXTRA_LAYOUTS_DIR = original_dir
+
+    def test_dir_files_merge_before_env_var_files(self):
+        with tempfile.TemporaryDirectory() as dir_tmpdir, tempfile.TemporaryDirectory() as env_tmpdir:
+            self.write_extra_file(dir_tmpdir, "a.json", {
+                "card_sizes": {"mtg": {"width": "2.5in", "height": "3.5in"}},
+            })
+            env_path = self.write_extra_file(env_tmpdir, "b.json", {
+                "card_sizes": {"sorcery": {"width": "2.61in", "height": "3.74in"}},
+            })
+            original_dir = utilities.EXTRA_LAYOUTS_DIR
+            utilities.EXTRA_LAYOUTS_DIR = Path(dir_tmpdir)
+            os.environ[EXTRA_LAYOUTS_ENV] = env_path
+            try:
+                config = merge_extra_layouts(self.base_config())
+                assert "mtg" in config["card_sizes"]
+                assert "sorcery" in config["card_sizes"]
+            finally:
+                utilities.EXTRA_LAYOUTS_DIR = original_dir
+                del os.environ[EXTRA_LAYOUTS_ENV]
 
 
 class TestAddFrontBackPages:

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -28,6 +28,7 @@ from utilities import (
     FitMode,
     asset_directory,
     merge_extra_layouts,
+    extra_layout_paths,
     EXTRA_LAYOUTS_ENV,
 )
 from enums import Orientation
@@ -1578,6 +1579,40 @@ class TestDrawCardLayout:
         # Right: card ends at x=150, extends 15 pixels from x=150 to x=164
         assert base.getpixel((164, 50)) == self.RED
         assert base.getpixel((165, 50)) == self.WHITE
+
+
+class TestExtraLayoutPaths:
+    """Tests for extra_layout_paths()."""
+
+    def write_json(self, tmpdir, name, data=None):
+        path = Path(tmpdir) / name
+        with open(path, 'w') as f:
+            json.dump(data or {}, f)
+        return path
+
+    def test_empty_when_nothing_configured(self):
+        os.environ.pop(EXTRA_LAYOUTS_ENV, None)
+        original_dir = utilities.EXTRA_LAYOUTS_DIR
+        utilities.EXTRA_LAYOUTS_DIR = Path(tempfile.gettempdir()) / "scm-test-nonexistent-dir"
+        try:
+            assert extra_layout_paths() == []
+        finally:
+            utilities.EXTRA_LAYOUTS_DIR = original_dir
+
+    def test_dir_files_sorted_before_env_files(self):
+        with tempfile.TemporaryDirectory() as dir_tmpdir, tempfile.TemporaryDirectory() as env_tmpdir:
+            b_path = self.write_json(dir_tmpdir, "b.json")
+            a_path = self.write_json(dir_tmpdir, "a.json")
+            env_path = self.write_json(env_tmpdir, "c.json")
+
+            original_dir = utilities.EXTRA_LAYOUTS_DIR
+            utilities.EXTRA_LAYOUTS_DIR = Path(dir_tmpdir)
+            os.environ[EXTRA_LAYOUTS_ENV] = str(env_path)
+            try:
+                assert extra_layout_paths() == [a_path, b_path, env_path]
+            finally:
+                utilities.EXTRA_LAYOUTS_DIR = original_dir
+                del os.environ[EXTRA_LAYOUTS_ENV]
 
 
 class TestMergeExtraLayouts:

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -29,6 +29,7 @@ from utilities import (
     asset_directory,
     merge_extra_layouts,
     extra_layout_paths,
+    find_extra_layout_owner,
     EXTRA_LAYOUTS_ENV,
 )
 from enums import Orientation
@@ -1613,6 +1614,44 @@ class TestExtraLayoutPaths:
             finally:
                 utilities.EXTRA_LAYOUTS_DIR = original_dir
                 del os.environ[EXTRA_LAYOUTS_ENV]
+
+
+class TestFindExtraLayoutOwner:
+    """Tests for find_extra_layout_owner()."""
+
+    def write_json(self, tmpdir, name, data):
+        path = Path(tmpdir) / name
+        with open(path, 'w') as f:
+            json.dump(data, f)
+        return path
+
+    def test_finds_defining_file_among_several(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mtg_path = self.write_json(tmpdir, "a-mtg.json", {
+                "card_sizes": {"mtg": {"width": "2.5in", "height": "3.5in"}},
+            })
+            sorcery_path = self.write_json(tmpdir, "b-sorcery.json", {
+                "card_sizes": {"sorcery": {"width": "2.61in", "height": "3.74in"}},
+            })
+            original_dir = utilities.EXTRA_LAYOUTS_DIR
+            utilities.EXTRA_LAYOUTS_DIR = Path(tmpdir)
+            try:
+                assert find_extra_layout_owner("card_sizes", "sorcery") == sorcery_path
+                assert find_extra_layout_owner("card_sizes", "mtg") == mtg_path
+            finally:
+                utilities.EXTRA_LAYOUTS_DIR = original_dir
+
+    def test_returns_none_when_not_found(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.write_json(tmpdir, "a.json", {
+                "card_sizes": {"mtg": {"width": "2.5in", "height": "3.5in"}},
+            })
+            original_dir = utilities.EXTRA_LAYOUTS_DIR
+            utilities.EXTRA_LAYOUTS_DIR = Path(tmpdir)
+            try:
+                assert find_extra_layout_owner("card_sizes", "nonexistent") is None
+            finally:
+                utilities.EXTRA_LAYOUTS_DIR = original_dir
 
 
 class TestMergeExtraLayouts:

--- a/utilities.py
+++ b/utilities.py
@@ -39,7 +39,7 @@ EXTRA_LAYOUTS_ENV = 'SCM_EXTRA_LAYOUTS'
 
 # Optional override for where cutting templates get written/read (default: SCRIPT_DIR-relative
 # cutting_templates/ directories in generate_dxf.py and dxf_to_studio3.py).
-OUTPUT_DIR_ENV = 'SCM_CUTTING_TEMPLATES_DIR'
+CUTTING_TEMPLATES_DIR_ENV = 'SCM_CUTTING_TEMPLATES_DIR'
 
 # Specify valid mimetypes for images
 # List can be found here: https://github.com/h2non/filetype.py?tab=readme-ov-file#image
@@ -156,21 +156,28 @@ class LayoutConfig(BaseModel):
     specialty_layouts: Optional[Dict[str, SpecialtyLayoutDef]] = None
 
 
-def merge_extra_layouts(raw_config: dict) -> dict:
-    """Merge extra card_sizes/paper_sizes/layouts on top of raw_config, in place.
+def extra_layout_paths() -> list[Path]:
+    """Return every extra layout file, in merge/precedence order.
 
-    Merges every *.json file found in EXTRA_LAYOUTS_DIR (sorted by filename), followed by
-    every file in EXTRA_LAYOUTS_ENV (an os.pathsep-separated list), into raw_config's
-    card_sizes/paper_sizes/layouts dicts, in that order. Each key (card size, paper size, or
-    paper+card+variant layout) must be new: raise ValueError on any collision with raw_config
-    or an earlier file in the merge, since these files are meant to be pure additions, not
-    overrides. No-op if EXTRA_LAYOUTS_DIR doesn't exist and EXTRA_LAYOUTS_ENV is unset/empty.
+    Every *.json file found in EXTRA_LAYOUTS_DIR (sorted by filename), followed by every
+    file listed in EXTRA_LAYOUTS_ENV (an os.pathsep-separated list). Empty if neither is
+    configured.
     """
     dir_paths = sorted(EXTRA_LAYOUTS_DIR.glob('*.json')) if EXTRA_LAYOUTS_DIR.is_dir() else []
     env_paths = [Path(p) for p in os.environ.get(EXTRA_LAYOUTS_ENV, '').split(os.pathsep) if p]
-    paths = dir_paths + env_paths
+    return dir_paths + env_paths
 
-    for path in paths:
+
+def merge_extra_layouts(raw_config: dict) -> dict:
+    """Merge extra card_sizes/paper_sizes/layouts on top of raw_config, in place.
+
+    Merges every file from extra_layout_paths(), in order, into raw_config's
+    card_sizes/paper_sizes/layouts dicts. Each key (card size, paper size, or
+    paper+card+variant layout) must be new: raise ValueError on any collision with raw_config
+    or an earlier file in the merge, since these files are meant to be pure additions, not
+    overrides. No-op if extra_layout_paths() is empty.
+    """
+    for path in extra_layout_paths():
         with open(path, 'r') as f:
             extra = json.load(f)
 
@@ -190,9 +197,9 @@ def merge_extra_layouts(raw_config: dict) -> dict:
     return raw_config
 
 
-def resolve_output_dir(default: Path) -> Path:
-    """Return the OUTPUT_DIR_ENV override if set, else default."""
-    override = os.environ.get(OUTPUT_DIR_ENV)
+def resolve_cutting_templates_dir(default: Path) -> Path:
+    """Return the CUTTING_TEMPLATES_DIR_ENV override if set, else default."""
+    override = os.environ.get(CUTTING_TEMPLATES_DIR_ENV)
     return Path(override) if override else default
 
 

--- a/utilities.py
+++ b/utilities.py
@@ -168,6 +168,16 @@ def extra_layout_paths() -> list[Path]:
     return dir_paths + env_paths
 
 
+def find_extra_layout_owner(section: str, key: str) -> Path | None:
+    """Return the first file from extra_layout_paths() whose `section` dict already
+    contains `key` (e.g. section='card_sizes', key='mtg'), or None if none do."""
+    for path in extra_layout_paths():
+        with open(path, 'r') as f:
+            if key in json.load(f).get(section, {}):
+                return path
+    return None
+
+
 def merge_extra_layouts(raw_config: dict) -> dict:
     """Merge extra card_sizes/paper_sizes/layouts on top of raw_config, in place.
 

--- a/utilities.py
+++ b/utilities.py
@@ -26,6 +26,21 @@ asset_directory = SCRIPT_DIR / 'assets'
 layouts_filename = 'layouts.json'
 layouts_path = asset_directory / layouts_filename
 
+# Optional extra layout definitions to merge on top of layouts.json. Lets a layout-consuming
+# project layer its own card sizes, paper sizes, and layouts on top of this repo's without
+# modifying it. Opt-in: both are empty/unset by default, so load_layout_config() behaves
+# exactly as if this didn't exist. Two ways to supply extra files, merged in this order:
+#   1. Drop any number of *.json files into EXTRA_LAYOUTS_DIR (merged in filename order) -
+#      no configuration needed, just copy a file in.
+#   2. Point EXTRA_LAYOUTS_ENV at one or more file paths (os.pathsep-separated, merged in
+#      order) - for files that live outside EXTRA_LAYOUTS_DIR.
+EXTRA_LAYOUTS_DIR = asset_directory / 'extra_layouts'
+EXTRA_LAYOUTS_ENV = 'SCM_EXTRA_LAYOUTS'
+
+# Optional override for where cutting templates get written/read (default: SCRIPT_DIR-relative
+# cutting_templates/ directories in generate_dxf.py and dxf_to_studio3.py).
+OUTPUT_DIR_ENV = 'SCM_CUTTING_TEMPLATES_DIR'
+
 # Specify valid mimetypes for images
 # List can be found here: https://github.com/h2non/filetype.py?tab=readme-ov-file#image
 # Pillow suported formats: https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html
@@ -141,10 +156,53 @@ class LayoutConfig(BaseModel):
     specialty_layouts: Optional[Dict[str, SpecialtyLayoutDef]] = None
 
 
+def merge_extra_layouts(raw_config: dict) -> dict:
+    """Merge extra card_sizes/paper_sizes/layouts on top of raw_config, in place.
+
+    Merges every *.json file found in EXTRA_LAYOUTS_DIR (sorted by filename), followed by
+    every file in EXTRA_LAYOUTS_ENV (an os.pathsep-separated list), into raw_config's
+    card_sizes/paper_sizes/layouts dicts, in that order. Each key (card size, paper size, or
+    paper+card+variant layout) must be new: raise ValueError on any collision with raw_config
+    or an earlier file in the merge, since these files are meant to be pure additions, not
+    overrides. No-op if EXTRA_LAYOUTS_DIR doesn't exist and EXTRA_LAYOUTS_ENV is unset/empty.
+    """
+    dir_paths = sorted(EXTRA_LAYOUTS_DIR.glob('*.json')) if EXTRA_LAYOUTS_DIR.is_dir() else []
+    env_paths = [Path(p) for p in os.environ.get(EXTRA_LAYOUTS_ENV, '').split(os.pathsep) if p]
+    paths = dir_paths + env_paths
+
+    for path in paths:
+        with open(path, 'r') as f:
+            extra = json.load(f)
+
+        for section in ('card_sizes', 'paper_sizes'):
+            for key, value in extra.get(section, {}).items():
+                if key in raw_config[section]:
+                    raise ValueError(f"'{key}' in {section} of {path} already defined")
+                raw_config[section][key] = value
+
+        for paper, cards in extra.get('layouts', {}).items():
+            for card, variants in cards.items():
+                for variant, layout_def in variants.items():
+                    if variant in raw_config['layouts'].get(paper, {}).get(card, {}):
+                        raise ValueError(f"layout '{paper}'/'{card}'/'{variant}' in {path} already defined")
+                    raw_config['layouts'].setdefault(paper, {}).setdefault(card, {})[variant] = layout_def
+
+    return raw_config
+
+
+def resolve_output_dir(default: Path) -> Path:
+    """Return the OUTPUT_DIR_ENV override if set, else default."""
+    override = os.environ.get(OUTPUT_DIR_ENV)
+    return Path(override) if override else default
+
+
 def load_layout_config() -> LayoutConfig:
-    """Load and validate layouts.json from the assets directory."""
+    """Load and validate layouts.json from the assets directory, merging in any extra
+    layout definitions from EXTRA_LAYOUTS_ENV."""
     with open(layouts_path, 'r') as f:
-        return LayoutConfig(**json.load(f))
+        raw_config = json.load(f)
+    merge_extra_layouts(raw_config)
+    return LayoutConfig(**raw_config)
 
 
 # Borderless mode tricks Silhouette Studio into using a smaller effective inset than its


### PR DESCRIPTION
## Summary

- `load_layout_config()` now detects and merges `assets/layouts-extra.json` if present
- Extra `card_sizes`, `layouts`, and `specialty_layouts` are merged on top of the base config
- All SCM scripts that call `load_layout_config()` gain the extra sizes automatically — no per-script changes needed
- Backwards compatible: if the file is absent, behaviour is unchanged

## Motivation

Enables a companion repo ([scm-extras](https://github.com/alan-cha/scm-extras)) to define game-specific card sizes (e.g. MTG at 2.5 mm radius, Sorcery: Contested Realm) without duplicating paper sizes or other base data from `layouts.json`. The companion repo ships only a small delta file and symlinks it into `assets/` at generation time.

## Test plan

- [ ] Verify existing tests pass with no `layouts-extra.json` present
- [ ] Verify `generate_dxf.py list` shows extra card sizes when `assets/layouts-extra.json` is symlinked in
- [ ] Verify `generate_dxf.py single` and `create_pdf.py` resolve extra card sizes correctly

Signed-off-by: Alan Cha <Alan.cha1@ibm.com>