### PR TITLE
feat(mtg): memoise remote queries

### DIFF
--- a/plugins/mtg/fetch.py
+++ b/plugins/mtg/fetch.py
@@ -7,6 +7,7 @@ import click
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 sys.path.insert(0, REPO_ROOT)
 
+from plugins.mtg import remote
 from plugins.mtg.common import ScryfallLanguage
 from plugins.mtg.deck_formats import DeckFormat, parse_deck, extract_mpcfill_card_ids
 from plugins.mtg.scryfall import get_handle_card as scryfall_get_handle_card
@@ -94,6 +95,8 @@ def cli(
         front_directory,
         double_sided_directory,
     )
+
+    remote.cache_trim()
 
 if __name__ == '__main__':
     cli()

--- a/plugins/mtg/mpcfill.py
+++ b/plugins/mtg/mpcfill.py
@@ -22,12 +22,11 @@ from base64 import b64decode
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Set
 
-import requests
 from filetype.filetype import guess_extension
 
-from .common import remove_nonalphanumeric
+from plugins.mtg import remote
 
-session = requests.Session()
+from .common import remove_nonalphanumeric
 
 # Cache for fetched images: card_id -> decoded image bytes.
 # Populated by prefetch_mpcfill() and read by get_cached_image().
@@ -38,12 +37,11 @@ _image_cache: dict[str, bytes] = {}
 # up to 8 simultaneous downloads.
 MAX_WORKERS = 8
 
-
+@remote.memo
 def request_mpcfill(card_id: str) -> bytes:
     """Fetch a single card image from MPCFill API and return decoded bytes."""
     base_url = "https://script.google.com/macros/s/AKfycbw8laScKBfxda2Wb0g63gkYDBdy8NWNxINoC4xDOwnCQ3JMFdruam1MdmNmN4wI5k4/exec?id="
-    r = session.get(base_url + card_id, headers={"user-agent": "silhouette-card-maker/0.1", "accept": "*/*"})
-    r.raise_for_status()
+    r = remote.get(base_url + card_id)
     return b64decode(r.content)
 
 

--- a/plugins/mtg/remote.py
+++ b/plugins/mtg/remote.py
@@ -1,0 +1,68 @@
+import pathlib
+from datetime import timedelta
+import time
+from typing import Any, Callable
+
+import joblib
+import requests
+
+# CONFIGURABLE
+# cmdr deck is ~100mb, so store the last two
+_CACHE_SIZE_MAX = 256 * 1024 * 1024
+# assume the data does not change that often and we can keep the last day
+_CACHE_AGE_MAX = timedelta(days=1)
+_GET_RETRIES = 3
+_GET_RETRY_DELAY = timedelta(seconds=30)
+
+# CONSTANTS
+_HTTP_RATE_LIMITED = 429
+_CACHE_DIR = pathlib.Path(__file__).parent / ".cache-remote"
+_CACHE_DIR.mkdir(exist_ok=True)
+_SCRYFALL_RETRY_DELAY_MIN = timedelta(seconds=30)
+
+
+_GET_HEADERS = {
+    'user-agent': 'silhouette-card-maker/0.1',
+    'accept': '*/*',
+}
+
+# STATE
+_cache = joblib.Memory(
+    # Don't bother with compression. Majority of it is images and those are incompressible.
+    location=_CACHE_DIR,
+    verbose=0,
+)
+_session = requests.Session()
+
+# INVARIANTS
+assert 0 < _CACHE_SIZE_MAX
+assert timedelta() < _CACHE_AGE_MAX
+assert 0 < _GET_RETRIES
+assert _SCRYFALL_RETRY_DELAY_MIN <= _GET_RETRY_DELAY, "Scryfall requires at least 30s between retries"
+
+def memo(func: Callable | None = None):
+    if func is None: # no partial args at this time, just give a plain wrapper
+      return lambda func: memo(func)
+
+    return _cache.cache(func)
+
+def get(query: str, params: dict[str, Any] | None = None) -> requests.Response:
+    for i in range(_GET_RETRIES):
+        r = _session.get(query, params=params, headers = _GET_HEADERS)
+        # Rate limit check - Scryfall requires 30 second wait per their documentation
+        if r.status_code != _HTTP_RATE_LIMITED:
+            r.raise_for_status()
+            return r
+
+        print(f"Hit rate limit ({_HTTP_RATE_LIMITED}), waiting {_GET_RETRY_DELAY} seconds before retry {i + 1}/{_GET_RETRIES}...")
+        time.sleep(_GET_RETRY_DELAY.total_seconds())
+
+    assert isinstance(r, requests.Response)
+    print(f"Warning: Hit rate limit {_GET_RETRIES} times for {query}, giving up.")
+    raise requests.exceptions.HTTPError(f"Max retries ({_GET_RETRIES}) exceeded query: {query}", response=r)
+
+def cache_trim():
+    _cache.reduce_size(
+        bytes_limit=_CACHE_SIZE_MAX,
+        age_limit=_CACHE_AGE_MAX,
+    )

--- a/plugins/mtg/scryfall.py
+++ b/plugins/mtg/scryfall.py
@@ -1,17 +1,16 @@
 import os
+import time
 from io import BytesIO
 from typing import List, Optional, Tuple
-from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
-import requests
-import time
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
+import requests
 from PIL import Image
 
-from .common import remove_nonalphanumeric, ScryfallLanguage, to_scryfall_api_lang
+from . import remote
+from .common import ScryfallLanguage, remove_nonalphanumeric, to_scryfall_api_lang
 
 double_sided_layouts = ['transform', 'modal_dfc', 'double_faced_token', 'reversible_card', 'meld']
-
-session = requests.Session()
 
 def append_search_filter(uri: str, filter_term: str) -> str:
     parsed = urlparse(uri)
@@ -35,23 +34,12 @@ def fetch_printings(prints_search_uri: str, prefer_ub: Optional[bool], name: str
         print(f'{label} printings for "{name}" are Universe Beyond. Ignoring {flag}.')
     return request_scryfall(prints_search_uri).json()['data']
 
+@remote.memo
 def request_scryfall(
     query: str,
     params: dict = None,
-    retry_count: int = 0,
 ) -> requests.Response:
-    r = session.get(query, params=params, headers = {'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
-
-    # Rate limit check - Scryfall requires 30 second wait per their documentation
-    if r.status_code == 429:
-        if retry_count >= 3:
-            print(f"Warning: Hit rate limit 3 times for {query}, giving up after 30s wait")
-            raise requests.exceptions.HTTPError(f"Max retries (3) exceeded for Scryfall API: {query}", response=r)
-        print(f"Hit Scryfall rate limit (429), waiting 30 seconds before retry {retry_count + 1}/3...")
-        time.sleep(30)
-        return request_scryfall(query, params, retry_count + 1)
-
-    r.raise_for_status()
+    r = remote.get(query, params)
 
     # Apply rate limiting per Scryfall API documentation
     # See: https://scryfall.com/docs/api/rate-limits

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click==8.1.8
 cloudscraper==1.2.71
 ezdxf==1.4.2
 filetype==1.2.0
+joblib==1.5.3
 matplotlib==3.10.5
 mtg_parser==0.0.1a50
 natsort==8.4.0
@@ -9,7 +10,7 @@ numpy==2.4.2
 pillow==12.1.1
 pyautogui==0.9.54
 pydantic==2.12.5
-pywinauto==0.6.9
 pypdfium2==4.30.0
+pywinauto==0.6.9
 requests==2.32.4
 split-image==2.0.1

--- a/test/test_mtg_plugin.py
+++ b/test/test_mtg_plugin.py
@@ -603,7 +603,7 @@ class TestScryfallFetch:
 
         mock_fetch_art.assert_called_once()
 
-    @patch('plugins.mtg.scryfall.session.get')
+    @patch('plugins.mtg.scryfall.remote._session.get')
     def test_image_fetched_with_lowercase_set_code(self, mock_get):
         """When given an uppercase set code, the image is fetched using the lowercase code returned by the API."""
         info_response = MagicMock(status_code=200)


### PR DESCRIPTION
Memoise remote HTTP queries in the MTG plugin. The cache is limited to 256MiB, and 1 day stale.
Saves a lot of time when fiddling with a commander deck. Fetching goes from 60s -> 2s, and we don't rudely re-request a bunch of data from Scryfall.

```
> python -m pytest test/test_mtg_plugin.py -m "not integration"
....
44 passed, 19 deselected, 1 warning in 1.77s
```