### PR TITLE
feat(mtg): overhaul + token pairing feature

### DIFF
--- a/plugins/mtg/common.py
+++ b/plugins/mtg/common.py
@@ -1,10 +1,22 @@
 import re
-from enum import Enum
+import enum
+from typing import Callable, Iterable, TypeVar
+
+_A = TypeVar("_A")
+
+def partition(xs: Iterable[_A], fn: Callable[[_A], bool]) -> tuple[list[_A], list[_A]]:
+    a: list[_A] = []
+    b: list[_A] = []
+    for x in xs:
+        (a if fn(x) else b).append(x)
+    return a, b
 
 def remove_nonalphanumeric(s: str) -> str:
     return re.sub(r'[^\w]', '', s)
 
-class ScryfallLanguage(Enum):
+# Language code as printed on the card.
+# n.b. Scryfall uses a different code set for their data. See `scryfall.Language`.
+class MtgPrintedLanguage(enum.StrEnum):
     ENGLISH            = "en"
     SPANISH            = "sp"
     FRENCH             = "fr"
@@ -18,23 +30,3 @@ class ScryfallLanguage(Enum):
     TRADITIONAL_CHINESE = "ct"
     ANCIENT_GREEK      = "ag"
     PHYREXIAN          = "ph"
-
-# Maps the printed code (enum value) to the Scryfall API language code
-PRINTED_TO_API_LANG: dict[str, str] = {
-    "en": "en",
-    "sp": "es",
-    "fr": "fr",
-    "de": "de",
-    "it": "it",
-    "pt": "pt",
-    "jp": "ja",
-    "kr": "ko",
-    "ru": "ru",
-    "cs": "zhs",
-    "ct": "zht",
-    "ag": "grc",
-    "ph": "ph",
-}
-
-def to_scryfall_api_lang(lang: ScryfallLanguage) -> str:
-    return PRINTED_TO_API_LANG[lang.value]

--- a/plugins/mtg/deck_formats.py
+++ b/plugins/mtg/deck_formats.py
@@ -1,52 +1,67 @@
 import csv
 import io
 import json
-import os
 import re
-
+from collections import OrderedDict
 from enum import Enum
-from typing import Callable, Tuple
+from typing import Any, Callable, Iterable, Tuple
 from xml.etree import ElementTree as ET
 
-from pyparsing import line
+import cloudscraper
+import mtg_parser
 
 from plugins.mtg.patterns import DECKSTATS_PATTERN, MOXFIELD_PATTERN
+from plugins.mtg import scryfall
 
-import cloudscraper
-import filetype
-import mtg_parser
-import requests
+type DeckEntry = Tuple[CardName, SetCode | None, CollectorNumber | None, int]
+type FetchCard = Callable[[CardName, SetCode | None, CollectorNumber | None], scryfall.Card]
+type DeckParse = tuple[list[tuple[str, Exception]], OrderedDict[scryfall.Card, int]]
 
-from plugins.mtg.common import remove_nonalphanumeric
+# Deck parsing needs to be overhauled w/ better abstractions.
+def parse_deck_helper2(
+    deck_entries: Iterable[tuple[str, DeckEntry]],
+    fetch_card: FetchCard,
+) -> DeckParse:
+    cards = OrderedDict[scryfall.Card, int]() # annoyingly there's no shrink-wrapped ordered-default-dict.
+    errors: list[tuple[str, Exception]] = []
 
-card_data_tuple = Tuple[str, str, int, int]
+    # `raw` sucks. this whole abstraction mechanism sucks.
+    for (raw, (name, set_code, collector_number, quantity)) in deck_entries:
+        parts = [f'quantity: {quantity}']
+        if set_code:
+            parts.append(f'set code: {set_code}')
+        if collector_number:
+            parts.append(f'collector number: {collector_number}')
+        if name:
+            parts.append(f'name: {name}')
+        print('fetching: ' + ', '.join(parts))
 
-def parse_deck_helper(deck_text: str, is_card_line: Callable[[str], bool], extract_card_data: Callable[[str], card_data_tuple], handle_card: Callable) -> None:
-    error_lines = []
+        try:
+            card = fetch_card(name, set_code, collector_number)
+        except Exception as e:
+            errors.append((raw, e))
+            raise # DEBUG
 
-    index = 0
+        cards.setdefault(card, 0)
+        cards[card] += quantity
+
+    return (errors, cards)
+
+def parse_deck_helper(
+    deck_text: str,
+    is_card_line: Callable[[str], bool],
+    parse_deck_line: Callable[[str], DeckEntry],
+    fetch_card: FetchCard,
+) -> DeckParse:
+    entries: list[tuple[str, DeckEntry]] = []
     for line in deck_text.strip().split('\n'):
         if is_card_line(line):
-            index = index + 1
-
-            name, set_code, collector_number, quantity = extract_card_data(line)
-
-            parts = [f'Index: {index}', f'quantity: {quantity}']
-            if set_code: parts.append(f'set code: {set_code}')
-            if collector_number: parts.append(f'collector number: {collector_number}')
-            if name: parts.append(f'name: {name}')
-            print(', '.join(parts))
-            try:
-                handle_card(index, name, set_code, collector_number, quantity)
-            except Exception as e:
-                print(f'Error: {e}')
-                error_lines.append((line, e))
-
+            entries.append((line, parse_deck_line(line)))
         else:
             print(f'Skipping: "{line}"')
 
-    if len(error_lines) > 0:
-        print(f'Errors: {error_lines}')
+    return parse_deck_helper2(entries, fetch_card)
+
 
 # Isshin, Two Heavens as One
 # Arid Mesa
@@ -54,14 +69,14 @@ def parse_deck_helper(deck_text: str, is_card_line: Callable[[str], bool], extra
 # Blazemire Verge
 # Blightstep Pathway
 # Blood Crypt
-def parse_simple_list(deck_text, handle_card: Callable) -> None:
-    def is_simple_card_line(line) -> bool:
+def parse_simple_list(deck_text: str, fetch_card: FetchCard) ->DeckParse:
+    def is_simple_card_line(line: str) -> bool:
         return bool(line.strip())
 
-    def extract_simple_card_data(line) -> card_data_tuple:
-        return (line.strip(), "", "", 1)
+    def extract_simple_card_data(line: str) -> DeckEntry:
+        return (line.strip(), None, None, 1)
 
-    parse_deck_helper(deck_text, is_simple_card_line, extract_simple_card_data, handle_card)
+    return parse_deck_helper(deck_text, is_simple_card_line, extract_simple_card_data, fetch_card)
 
 # About
 # Name Death & Taxes
@@ -75,16 +90,17 @@ def parse_simple_list(deck_text, handle_card: Callable) -> None:
 # 1 Loran of the Third Path
 # 2 Witch Enchanter
 
+
 # Sideboard
 # 1 Containment Priest
-def parse_mtga(deck_text, handle_card: Callable) -> None:
+def parse_mtga(deck_text: str, fetch_card: FetchCard) -> DeckParse:
     pattern = re.compile(r'(\d+)x?\s+(.+?)\s+\((\w+)\)\s+(\d+)', re.IGNORECASE)
     fallback_pattern = re.compile(r'(\d+)x?\s+(.+)')
 
-    def is_mtga_card_line(line) -> bool:
+    def is_mtga_card_line(line: str) -> bool:
         return bool(pattern.match(line) or fallback_pattern.match(line))
 
-    def extract_mtga_card_data(line) -> card_data_tuple:
+    def extract_mtga_card_data(line: str) -> DeckEntry:
         match = pattern.match(line)
         if match:
             quantity = int(match.group(1))
@@ -96,12 +112,14 @@ def parse_mtga(deck_text, handle_card: Callable) -> None:
         else:
             # Handle simpler "1x Mountain" lines
             fallback_match = fallback_pattern.match(line)
+            assert fallback_match is not None
             quantity = int(fallback_match.group(1))
             name = fallback_match.group(2).strip()
 
-            return (name, "", "", quantity)
+            return (name, None, None, quantity)
 
-    parse_deck_helper(deck_text, is_mtga_card_line, extract_mtga_card_data, handle_card)
+    return parse_deck_helper(deck_text, is_mtga_card_line, extract_mtga_card_data, fetch_card)
+
 
 # 1 Abzan Battle Priest
 # 1 Abzan Falconer
@@ -110,22 +128,24 @@ def parse_mtga(deck_text, handle_card: Callable) -> None:
 # 1 Angel of Condemnation
 # 2 Witch Enchanter
 
+
 # SIDEBOARD:
 # 1 Containment Priest
 # 3 Deafening Silence
 # 2 Disruptor Flute
-def parse_mtgo(deck_text, handle_card: Callable) -> None:
-    def is_mtgo_card_line(line) -> bool:
+def parse_mtgo(deck_text: str, fetch_card: FetchCard) -> DeckParse:
+    def is_mtgo_card_line(line: str) -> bool:
         line = line.strip()
         return bool(line and line[0].isdigit())
 
-    def extract_mtgo_card_data(line) -> card_data_tuple:
+    def extract_mtgo_card_data(line: str) -> DeckEntry:
         parts = line.split(' ', 1)
         quantity = int(parts[0])
         name = parts[1].strip()
-        return (name, "", "", quantity)
+        return (name, None, None, quantity)
 
-    parse_deck_helper(deck_text, is_mtgo_card_line, extract_mtgo_card_data, handle_card)
+    return parse_deck_helper(deck_text, is_mtgo_card_line, extract_mtgo_card_data, fetch_card)
+
 
 # 1x Agadeem's Awakening // Agadeem, the Undercrypt (znr) 90 [Resilience,Land]
 # 1x Ancient Cornucopia (big) 16 [Maybeboard{noDeck}{noPrice},Mana Advantage]
@@ -133,13 +153,15 @@ def parse_mtgo(deck_text, handle_card: Callable) -> None:
 # 1x Ashnod's Altar (ema) 218 *F* [Mana Advantage]
 # 1x Assassin's Trophy (sld) 139 [Targeted Disruption]
 # 2x Boseiju Reaches Skyward // Branch of Boseiju (neo) 177 [Ramp] ^Have,#37d67a^
-def parse_archidekt(deck_text, handle_card: Callable) -> None:
-    pattern = re.compile(r'^(\d+)x?\s+(.+?)\s+\((\w+)\)\s+([\w\-]+).*')
+def parse_archidekt(deck_text: str, fetch_card: FetchCard) -> DeckParse:
+    pattern = re.compile(r'^(\d+)x?\s+(.+?)\s+\((\w+)\)\s+([\d\-]+).*')
+
     def is_archidekt_card_line(line: str) -> bool:
         return bool(pattern.match(line))
 
-    def extract_archidekt_card_data(line: str) -> card_data_tuple:
+    def extract_archidekt_card_data(line: str) -> DeckEntry:
         match = pattern.match(line)
+        assert match is not None
         quantity = int(match.group(1))
         name = match.group(2).strip()
         set_code = match.group(3).strip()
@@ -147,7 +169,10 @@ def parse_archidekt(deck_text, handle_card: Callable) -> None:
 
         return (name, set_code, collector_number, quantity)
 
-    parse_deck_helper(deck_text, is_archidekt_card_line, extract_archidekt_card_data, handle_card)
+    return parse_deck_helper(
+        deck_text, is_archidekt_card_line, extract_archidekt_card_data, fetch_card
+    )
+
 
 # //Main
 # 1 [2XM#310] Ash Barrens
@@ -159,22 +184,27 @@ def parse_archidekt(deck_text, handle_card: Callable) -> None:
 # //Sideboard
 # 1 [2XM#315] Darksteel Citadel
 
+
 # //Maybeboard
 # 1 [MID#159] Smoldering Egg // Ashmouth Dragon
-def parse_deckstats(deck_text, handle_card: Callable) -> None:
+def parse_deckstats(deck_text: str, fetch_card: FetchCard) -> DeckParse:
     def is_deckstats_card_line(line: str) -> bool:
         return bool(DECKSTATS_PATTERN.match(line))
 
-    def extract_deckstats_card_data(line: str) -> card_data_tuple:
+    def extract_deckstats_card_data(line: str) -> DeckEntry:
         match = DECKSTATS_PATTERN.match(line)
+        assert match is not None
         quantity = int(match.group(1))
-        set_code = match.group(2) or ""
-        collector_number = match.group(3) or ""
+        set_code = match.group(2)
+        collector_number = match.group(3)
         name = re.sub(r'\s*#!.*$', '', match.group(4).strip())
 
         return (name, set_code, collector_number, quantity)
 
-    parse_deck_helper(deck_text, is_deckstats_card_line, extract_deckstats_card_data, handle_card)
+    return parse_deck_helper(
+        deck_text, is_deckstats_card_line, extract_deckstats_card_data, fetch_card
+    )
+
 
 # 1 Lulu, Loyal Hollyphant (CLB) 477 *E*
 # 1 Abzan Battle Priest (IMA) 2
@@ -185,16 +215,18 @@ def parse_deckstats(deck_text, handle_card: Callable) -> None:
 # 4 Plains (MOM) 277
 # 2 Witch Enchanter // Witch-Blessed Meadow (MH3) 239
 
+
 # SIDEBOARD:
 # 1 Containment Priest (M21) 13
 # 1 Deafening Silence (MB2) 9
 # 1 Disruptor Flute (MH3) 209
-def parse_moxfield(deck_text, handle_card: Callable) -> None:
+def parse_moxfield(deck_text: str, fetch_card: FetchCard) -> DeckParse:
     def is_moxfield_card_line(line: str) -> bool:
         return bool(MOXFIELD_PATTERN.match(line))
 
-    def extract_moxfield_card_data(line: str) -> card_data_tuple:
+    def extract_moxfield_card_data(line: str) -> DeckEntry:
         match = MOXFIELD_PATTERN.match(line)
+        assert match is not None
         quantity = int(match.group(1))
         name = match.group(2).strip()
         set_code = match.group(3).strip()
@@ -202,51 +234,39 @@ def parse_moxfield(deck_text, handle_card: Callable) -> None:
 
         return (name, set_code, collector_number, quantity)
 
-    parse_deck_helper(deck_text, is_moxfield_card_line, extract_moxfield_card_data, handle_card)
+    return parse_deck_helper(
+        deck_text, is_moxfield_card_line, extract_moxfield_card_data, fetch_card
+    )
+
 
 # Scryfall deck builder JSON
-def parse_scryfall_json(deck_text, handle_card: Callable, front_img_dir: str = '', double_sided_dir: str = '') -> None:
+def parse_scryfall_json(
+    deck_text: str,
+    fetch_card: FetchCard,
+):
+    def parse(item: dict[str, Any]) -> DeckEntry | None:
+        card_digest = item.get("card_digest")
+        if card_digest is None: # TODO: is this even valid? error instead?
+            return None
+
+        name = card_digest["name"] # must have `name`
+        set_code = card_digest.get("set")
+        collector_number = card_digest.get("collector_number")
+        quantity = int(item.get("count", 1))
+
+        return (name, set_code, collector_number, quantity)
+
     data = json.loads(deck_text)
-    entries = data.get("entries", {})
-    for entry in entries.values():
-        for index, item in enumerate(entry, start=1):
-            card_digest = item.get("card_digest", {})
-            if card_digest is None:
-                continue
+    return parse_deck_helper2(
+        # lazy eval to allow helper to capture exceptions
+        ((json.dumps(item), deck_entry)
+         for entry in data.get("entries", {}).values()
+         for item in entry
+         if (deck_entry := parse(item)) is not None
+        ),
+        fetch_card
+    )
 
-            name = card_digest.get("name", "")
-            set_code = card_digest.get("set", "")
-            collector_number = card_digest.get("collector_number", "")
-            quantity = item.get("count", 1)
-            image_uris = card_digest.get("image_uris")
-
-            parts = [f'Index: {index}', f'quantity: {quantity}']
-            if set_code: parts.append(f'set code: {set_code}')
-            if collector_number: parts.append(f'collector number: {collector_number}')
-            if name: parts.append(f'name: {name}')
-            print(', '.join(parts))
-
-            # Scryfall JSON may already include image URIs, so we can fetch directly without an extra Scryfall API call. If not, fall back to handle_card which will query Scryfall by set/collector number or name.
-            if image_uris and front_img_dir:
-                clean_name = remove_nonalphanumeric(name)
-
-                front_url = image_uris.get("front")
-                if front_url:
-                    response = requests.get(front_url, headers={'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
-                    response.raise_for_status()
-                    for counter in range(quantity):
-                        with open(os.path.join(front_img_dir, f'{index}{clean_name}{counter + 1}.png'), 'wb') as f:
-                            f.write(response.content)
-
-                back_url = image_uris.get("back")
-                if back_url and double_sided_dir:
-                    response = requests.get(back_url, headers={'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
-                    response.raise_for_status()
-                    for counter in range(quantity):
-                        with open(os.path.join(double_sided_dir, f'{index}{clean_name}{counter + 1}.png'), 'wb') as f:
-                            f.write(response.content)
-            else:
-                handle_card(index, name, set_code, collector_number, quantity)
 
 # MPCFill XML
 def extract_card_name(raw_name: str) -> str:
@@ -258,30 +278,35 @@ def extract_card_name(raw_name: str) -> str:
 def extract_mpcfill_card_ids(deck_text: str) -> set[str]:
     """Extract all unique card IDs from MPCFill XML for prefetching."""
     data = ET.fromstring(deck_text)
-    card_ids = set()
+    card_ids = set[str]()
 
     fronts = data.find("fronts")
     if fronts:
         for front in fronts.findall("card"):
-            card_ids.add(front.find("id").text)
+            id = front.find("id").text
+            assert id is not None
+            card_ids.add(id)
 
     backs = data.find("backs")
     if backs:
         for back in backs.findall("card"):
-            card_ids.add(back.find("id").text)
+            id = back.find("id").text
+            assert id is not None
+            card_ids.add(id)
 
     return card_ids
 
 
-def parse_mpcfill_xml(deck_text, handle_card: Callable) -> None:
+def parse_mpcfill_xml(deck_text: str, fetch_card: FetchCard) -> DeckParse:
     """
-    Parse MPCFill XML and call handle_card once per slot.
+    Parse MPCFill XML and call fetch_card once per slot.
 
-    Each slot represents one physical card. handle_card signature:
-        handle_card(slot, front_id, front_name, back_id, back_name)
+    Each slot represents one physical card. fetch_card signature:
+        fetch_card(slot, front_id, front_name, back_id, back_name)
 
     back_id and back_name will be None if the slot has no custom back.
     """
+    assert False, "MPCFill XML is not implemented"
     data = ET.fromstring(deck_text)
     fronts = data.find("fronts")
     backs = data.find("backs")
@@ -289,7 +314,10 @@ def parse_mpcfill_xml(deck_text, handle_card: Callable) -> None:
     card_qty = int(data.find("details").find("quantity").text)
 
     # Create per-slot entries: {front_id, front_name, back_id, back_name}
-    slots = [{"front_id": None, "front_name": None, "back_id": None, "back_name": None} for _ in range(card_qty)]
+    slots = [
+        {"front_id": None, "front_name": None, "back_id": None, "back_name": None}
+        for _ in range(card_qty)
+    ]
 
     if fronts is None:
         raise ValueError("No fronts found in decklist")
@@ -313,7 +341,7 @@ def parse_mpcfill_xml(deck_text, handle_card: Callable) -> None:
                 slots[slot_idx]["back_id"] = card_id
                 slots[slot_idx]["back_name"] = name
 
-    # Call handle_card once per slot (1-indexed for display and filenames)
+    # Call fetch_card once per slot (1-indexed for display and filenames)
     for slot_idx, slot in enumerate(slots):
         slot_num = slot_idx + 1
         if slot["front_id"] is None:
@@ -327,110 +355,41 @@ def parse_mpcfill_xml(deck_text, handle_card: Callable) -> None:
 # Exported from CubeCobra (https://cubecobra.com)
 # CSV columns: name, CMC, Type, Color, Set, Collector Number, Rarity, Color Category,
 #              status, Finish, maybeboard, image URL, image Back URL, tags, Notes, MTGO ID, Custom
-#
-# Cards with an image URL are fetched directly. Cards without an image URL are fetched
-# from Scryfall using set and collector number, or by name as a fallback.
-# Identical cards are tallied to minimize Scryfall API calls.
-def parse_cubecobra_csv(deck_text, handle_card: Callable, front_img_dir: str, double_sided_dir: str) -> None:
+def parse_cubecobra_csv(deck_text: str, fetch_card: FetchCard) -> DeckParse:
     reader = csv.DictReader(io.StringIO(deck_text))
 
-    # Phase 1: Parse all rows and tally unique cards
-    # Key: (name, set_code, collector_number, image_url, image_back_url)
-    # Value: quantity (number of identical rows)
-    unique_cards = {}
+    def parse(row: dict[str, Any]) -> DeckEntry:
+        name = row['name']
+        set_code = row['Set']
+        collector_number = row['Collector Number']
+        # Previous impl aggregated by `(name, set, collector-number)`.
+        # Now we use the remote-caching mechanism to amortize.
+        return (name, set_code, collector_number, 1)
 
-    for row in reader:
-        name = row.get('name', '')
-        set_code = row.get('Set', '')
-        collector_number = row.get('Collector Number', '')
-        image_url = row.get('image URL', '')
-        image_back_url = row.get('image Back URL', '')
-
-        key = (name, set_code, collector_number, image_url, image_back_url)
-        unique_cards[key] = unique_cards.get(key, 0) + 1
-
-    total_cards = sum(unique_cards.values())
-    print(f'Parsed {total_cards} cards into {len(unique_cards)} unique entries')
-
-    # Phase 2: Process unique cards
-    error_lines = []
-
-    index = 0
-    for (name, set_code, collector_number, image_url, image_back_url), quantity in unique_cards.items():
-        index += 1
-
-        parts = [f'Index: {index}', f'quantity: {quantity}']
-        if set_code: parts.append(f'set code: {set_code}')
-        if collector_number: parts.append(f'collector number: {collector_number}')
-        if name: parts.append(f'name: {name}')
-        print(', '.join(parts))
-
-        try:
-            if image_url:
-                # Fetch image directly from URL
-                print(f'Fetching image from URL: {image_url}')
-                clean_name = remove_nonalphanumeric(name)
-                response = requests.get(image_url, headers={'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
-                response.raise_for_status()
-                kind = filetype.guess(response.content)
-                ext = f'.{kind.extension}' if kind else '.png'
-                for counter in range(quantity):
-                    image_path = os.path.join(front_img_dir, f'{str(index)}{clean_name}{str(counter + 1)}{ext}')
-                    with open(image_path, 'wb') as f:
-                        f.write(response.content)
-
-                if image_back_url:
-                    print(f'Fetching back image from URL: {image_back_url}')
-                    back_response = requests.get(image_back_url, headers={'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
-                    back_response.raise_for_status()
-                    back_kind = filetype.guess(back_response.content)
-                    back_ext = f'.{back_kind.extension}' if back_kind else '.png'
-                    for counter in range(quantity):
-                        image_path = os.path.join(double_sided_dir, f'{str(index)}{clean_name}{str(counter + 1)}{back_ext}')
-                        with open(image_path, 'wb') as f:
-                            f.write(back_response.content)
-            else:
-                # Fetch from Scryfall using set/collector number or name
-                handle_card(index, name, set_code, collector_number, quantity)
-        except Exception as e:
-            print(f'Error: {e}')
-            error_lines.append((name, e))
-
-    if len(error_lines) > 0:
-        print(f'Errors: {error_lines}')
+    return parse_deck_helper2(
+        # lazy eval to allow helper to capture exceptions
+        ((json.dumps(row), parse(row)) for row in reader),
+        fetch_card
+    )
 
 # URL Auto-Import
 #   Supported sites:
 #     Aetherhub, Archidekt, Deckstats, Moxfield, MTG Goldfish,
 #     MTGJSON, Scryfall, Tapped Out, TCGPlayer
-def parse_url(deck_url, handle_card: Callable) -> None:
+def parse_url(deck_url: str, fetch_card: FetchCard) -> DeckParse:
     scraper = cloudscraper.create_scraper()
+    # incorrect type sig (FFS!), does indeed return `Iter[Card] | None`
     cards = mtg_parser.parse_deck(deck_url, scraper)
-    if not cards:
+    if cards is None:
         print(f"Failed to parse deck from URL: {deck_url}")
-        return
+        return ([(deck_url, Exception("Failed to parse deck from URL"))], OrderedDict())
 
-    error_lines = []
+    return parse_deck_helper2(
+        (("", (card.name, card.extension, card.number, card.quantity))
+         for card in cards),
+        fetch_card
+    )
 
-    for index, card in enumerate(cards, start=1):
-        name = card.name
-        set_code = card.extension
-        collector_number = card.number
-        quantity = card.quantity
-
-        parts = [f'Index: {index}', f'quantity: {quantity}']
-        if set_code: parts.append(f'set code: {set_code}')
-        if collector_number: parts.append(f'collector number: {collector_number}')
-        if name: parts.append(f'name: {name}')
-        print(', '.join(parts))
-        try:
-            handle_card(index, name, set_code, collector_number, quantity)
-        except Exception as e:
-            print(f'Error: {e}')
-            error_lines.append((line, e))
-
-    if len(error_lines) > 0:
-        print(f'Errors: {error_lines}')
 
 class DeckFormat(str, Enum):
     ARCHIDEKT = "archidekt"
@@ -444,26 +403,60 @@ class DeckFormat(str, Enum):
     SIMPLE = "simple"
     URL = "url"
 
-def parse_deck(deck_text: str, format: DeckFormat, handle_card: Callable, front_img_dir: str = '', double_sided_dir: str = '') -> None:
-    if format == DeckFormat.SIMPLE:
-        parse_simple_list(deck_text, handle_card)
-    elif format == DeckFormat.MTGA:
-        parse_mtga(deck_text, handle_card)
-    elif format == DeckFormat.MTGO:
-        parse_mtgo(deck_text, handle_card)
-    elif format == DeckFormat.ARCHIDEKT:
-        parse_archidekt(deck_text, handle_card)
-    elif format == DeckFormat.DECKSTATS:
-        parse_deckstats(deck_text, handle_card)
-    elif format == DeckFormat.MOXFIELD:
-        parse_moxfield(deck_text, handle_card)
-    elif format == DeckFormat.SCRYFALL_JSON:
-        parse_scryfall_json(deck_text, handle_card, front_img_dir, double_sided_dir)
-    elif format == DeckFormat.MPCFILL_XML:
-        parse_mpcfill_xml(deck_text, handle_card)
-    elif format == DeckFormat.CUBECOBRA_CSV:
-        parse_cubecobra_csv(deck_text, handle_card, front_img_dir, double_sided_dir)
-    elif format == DeckFormat.URL:
-        parse_url(deck_text, handle_card)
-    else:
-        raise ValueError("Unrecognized deck format")
+
+def parse_deck(
+    deck_text: str,
+    format: DeckFormat,
+    fetch_card: FetchCard,
+) -> DeckParse:
+    match format:
+        case DeckFormat.SIMPLE:
+            return parse_simple_list(deck_text, fetch_card)
+        case DeckFormat.MTGA:
+            return parse_mtga(deck_text, fetch_card)
+        case DeckFormat.MTGO:
+            return parse_mtgo(deck_text, fetch_card)
+        case DeckFormat.ARCHIDEKT:
+            return parse_archidekt(deck_text, fetch_card)
+        case DeckFormat.DECKSTATS:
+            return parse_deckstats(deck_text, fetch_card)
+        case DeckFormat.MOXFIELD:
+            return parse_moxfield(deck_text, fetch_card)
+        case DeckFormat.SCRYFALL_JSON:
+            return parse_scryfall_json(deck_text, fetch_card)
+        case DeckFormat.MPCFILL_XML:
+            return parse_mpcfill_xml(deck_text, fetch_card)
+        case DeckFormat.CUBECOBRA_CSV:
+            return parse_cubecobra_csv(deck_text, fetch_card)
+        case DeckFormat.URL:
+            return parse_url(deck_text, fetch_card)
+
+
+def unparse(format: DeckFormat, card: 'scryfall.Card', quantity: int) -> str:
+    assert 0 < quantity
+    match format:
+        # 1x Ancient Cornucopia (big) 16 [Maybeboard{noDeck}{noPrice},Mana Advantage]
+        case DeckFormat.ARCHIDEKT: return f'{quantity}x {card.name} ({card.set}) {card.collector_number}'
+        # Don't bother with all the CSV fields.
+        # name, CMC, Type, Color, Set, Collector Number, Rarity, Color Category, status, Finish, maybeboard, image URL, image Back URL, tags, Notes, MTGO ID, Custom
+        case DeckFormat.CUBECOBRA_CSV:
+            s = io.StringIO()
+            w = csv.writer(s)
+            w.writerow([card.name, '', '', '', card.set, card.collector_number] + [''] * 11)
+            return '\n'.join([s.getvalue()] * quantity)
+        case DeckFormat.DECKSTATS: return f'{quantity} [{card.set}#{card.collector_number}] {card.name}'
+        case DeckFormat.MOXFIELD: return f'{quantity} {card.name} ({card.set}) {card.collector_number}'
+        case DeckFormat.MPCFILL_XML: raise NotImplemented
+        case DeckFormat.MTGA: return f'{quantity}x {card.name} ({card.set}) {card.collector_number}'
+        case DeckFormat.MTGO: return f'{quantity} {card.name}'
+        case DeckFormat.SCRYFALL_JSON: return json.dumps({
+            "count": quantity,
+            "card_digest": {
+                "name": card.name,
+                "set": card.set,
+                "collector_number": card.collector_number,
+            }
+        })
+        case DeckFormat.SIMPLE: return '\n'.join([card.name] * quantity)
+        # URL is a pseudo format and cannot be unparsed. Use moxfield syntax.
+        case DeckFormat.URL: return unparse(DeckFormat.MOXFIELD, card, quantity)

--- a/plugins/mtg/deck_formats.py
+++ b/plugins/mtg/deck_formats.py
@@ -2,7 +2,6 @@ import csv
 import io
 import json
 import re
-from collections import OrderedDict
 from enum import Enum
 from typing import Any, Callable, Iterable, Tuple
 from xml.etree import ElementTree as ET
@@ -10,23 +9,38 @@ from xml.etree import ElementTree as ET
 import cloudscraper
 import mtg_parser
 
-from plugins.mtg.patterns import DECKSTATS_PATTERN, MOXFIELD_PATTERN
 from plugins.mtg import scryfall
+from plugins.mtg.patterns import DECKSTATS_PATTERN, MOXFIELD_PATTERN
 
-type DeckEntry = Tuple[CardName, SetCode | None, CollectorNumber | None, int]
-type FetchCard = Callable[[CardName, SetCode | None, CollectorNumber | None], scryfall.Card]
-type DeckParse = tuple[list[tuple[str, Exception]], OrderedDict[scryfall.Card, int]]
+type Quantity = int  # INVARIANT: 0 <= x
+type DeckEntry = Tuple[
+    scryfall.CardName,
+    scryfall.SetCode | None,
+    scryfall.CollectorNumber | None,
+    Quantity,
+]
+type FetchCard = Callable[
+    [scryfall.CardName, scryfall.SetCode | None, scryfall.CollectorNumber | None],
+    scryfall.Card,
+]
+
+# In decl order.
+# *NOT* deduplicated. This matters for enabling fine-grain control of token pairing.
+# INVARIANT: 0 <= quantity   (weird, but allows token pairing tricks)
+type DeckList = list[tuple[scryfall.Card, int]]
+type DeckParse = tuple[list[tuple[str, Exception]], DeckList]
+
 
 # Deck parsing needs to be overhauled w/ better abstractions.
 def parse_deck_helper2(
     deck_entries: Iterable[tuple[str, DeckEntry]],
     fetch_card: FetchCard,
 ) -> DeckParse:
-    cards = OrderedDict[scryfall.Card, int]() # annoyingly there's no shrink-wrapped ordered-default-dict.
+    cards: list[tuple[scryfall.Card, Quantity]] = []
     errors: list[tuple[str, Exception]] = []
 
     # `raw` sucks. this whole abstraction mechanism sucks.
-    for (raw, (name, set_code, collector_number, quantity)) in deck_entries:
+    for raw, (name, set_code, collector_number, quantity) in deck_entries:
         parts = [f'quantity: {quantity}']
         if set_code:
             parts.append(f'set code: {set_code}')
@@ -40,12 +54,12 @@ def parse_deck_helper2(
             card = fetch_card(name, set_code, collector_number)
         except Exception as e:
             errors.append((raw, e))
-            raise # DEBUG
+            raise  # DEBUG
 
-        cards.setdefault(card, 0)
-        cards[card] += quantity
+        cards.append((card, quantity))
 
     return (errors, cards)
+
 
 def parse_deck_helper(
     deck_text: str,
@@ -69,14 +83,17 @@ def parse_deck_helper(
 # Blazemire Verge
 # Blightstep Pathway
 # Blood Crypt
-def parse_simple_list(deck_text: str, fetch_card: FetchCard) ->DeckParse:
+def parse_simple_list(deck_text: str, fetch_card: FetchCard) -> DeckParse:
     def is_simple_card_line(line: str) -> bool:
         return bool(line.strip())
 
     def extract_simple_card_data(line: str) -> DeckEntry:
         return (line.strip(), None, None, 1)
 
-    return parse_deck_helper(deck_text, is_simple_card_line, extract_simple_card_data, fetch_card)
+    return parse_deck_helper(
+        deck_text, is_simple_card_line, extract_simple_card_data, fetch_card
+    )
+
 
 # About
 # Name Death & Taxes
@@ -118,7 +135,9 @@ def parse_mtga(deck_text: str, fetch_card: FetchCard) -> DeckParse:
 
             return (name, None, None, quantity)
 
-    return parse_deck_helper(deck_text, is_mtga_card_line, extract_mtga_card_data, fetch_card)
+    return parse_deck_helper(
+        deck_text, is_mtga_card_line, extract_mtga_card_data, fetch_card
+    )
 
 
 # 1 Abzan Battle Priest
@@ -144,7 +163,9 @@ def parse_mtgo(deck_text: str, fetch_card: FetchCard) -> DeckParse:
         name = parts[1].strip()
         return (name, None, None, quantity)
 
-    return parse_deck_helper(deck_text, is_mtgo_card_line, extract_mtgo_card_data, fetch_card)
+    return parse_deck_helper(
+        deck_text, is_mtgo_card_line, extract_mtgo_card_data, fetch_card
+    )
 
 
 # 1x Agadeem's Awakening // Agadeem, the Undercrypt (znr) 90 [Resilience,Land]
@@ -246,10 +267,10 @@ def parse_scryfall_json(
 ):
     def parse(item: dict[str, Any]) -> DeckEntry | None:
         card_digest = item.get("card_digest")
-        if card_digest is None: # TODO: is this even valid? error instead?
+        if card_digest is None:  # TODO: is this even valid? error instead?
             return None
 
-        name = card_digest["name"] # must have `name`
+        name = card_digest["name"]  # must have `name`
         set_code = card_digest.get("set")
         collector_number = card_digest.get("collector_number")
         quantity = int(item.get("count", 1))
@@ -259,12 +280,13 @@ def parse_scryfall_json(
     data = json.loads(deck_text)
     return parse_deck_helper2(
         # lazy eval to allow helper to capture exceptions
-        ((json.dumps(item), deck_entry)
-         for entry in data.get("entries", {}).values()
-         for item in entry
-         if (deck_entry := parse(item)) is not None
+        (
+            (json.dumps(item), deck_entry)
+            for entry in data.get("entries", {}).values()
+            for item in entry
+            if (deck_entry := parse(item)) is not None
         ),
-        fetch_card
+        fetch_card,
     )
 
 
@@ -297,7 +319,9 @@ def extract_mpcfill_card_ids(deck_text: str) -> set[str]:
     return card_ids
 
 
-def parse_mpcfill_xml(deck_text: str, handle_card: Callable[[int, str, str, str | None, str | None], None]) -> None:
+def parse_mpcfill_xml(
+    deck_text: str, handle_card: Callable[[int, str, str, str | None, str | None], None]
+) -> None:
     """
     Parse MPCFill XML and call fetch_card once per slot.
 
@@ -347,8 +371,18 @@ def parse_mpcfill_xml(deck_text: str, handle_card: Callable[[int, str, str, str 
             print(f"Warning: Slot {slot_num} has no front image, skipping")
             continue
 
-        print(f"Slot {slot_num}: {slot['front_name']}" + (f" / {slot['back_name']}" if slot['back_id'] else ""))
-        handle_card(slot_num, slot["front_id"], slot["front_name"], slot["back_id"], slot["back_name"])
+        print(
+            f"Slot {slot_num}: {slot['front_name']}"
+            + (f" / {slot['back_name']}" if slot['back_id'] else "")
+        )
+        handle_card(
+            slot_num,
+            slot["front_id"],
+            slot["front_name"],
+            slot["back_id"],
+            slot["back_name"],
+        )
+
 
 # CubeCobra CSV
 # Exported from CubeCobra (https://cubecobra.com)
@@ -368,8 +402,9 @@ def parse_cubecobra_csv(deck_text: str, fetch_card: FetchCard) -> DeckParse:
     return parse_deck_helper2(
         # lazy eval to allow helper to capture exceptions
         ((json.dumps(row), parse(row)) for row in reader),
-        fetch_card
+        fetch_card,
     )
+
 
 # URL Auto-Import
 #   Supported sites:
@@ -381,12 +416,14 @@ def parse_url(deck_url: str, fetch_card: FetchCard) -> DeckParse:
     cards = mtg_parser.parse_deck(deck_url, scraper)
     if cards is None:
         print(f"Failed to parse deck from URL: {deck_url}")
-        return ([(deck_url, Exception("Failed to parse deck from URL"))], OrderedDict())
+        return ([(deck_url, Exception("Failed to parse deck from URL"))], [])
 
     return parse_deck_helper2(
-        (("", (card.name, card.extension, card.number, card.quantity))
-         for card in cards),
-        fetch_card
+        (
+            ("", (card.name, card.extension, card.number, card.quantity))
+            for card in cards
+        ),
+        fetch_card,
     )
 
 
@@ -424,7 +461,9 @@ def parse_deck(
         case DeckFormat.SCRYFALL_JSON:
             return parse_scryfall_json(deck_text, fetch_card)
         case DeckFormat.MPCFILL_XML:
-            raise ValueError("`MPCFILL_XML` is not supported and has its own dispatcher")
+            raise ValueError(
+                "`MPCFILL_XML` is not supported and has its own dispatcher"
+            )
         case DeckFormat.CUBECOBRA_CSV:
             return parse_cubecobra_csv(deck_text, fetch_card)
         case DeckFormat.URL:
@@ -435,27 +474,40 @@ def unparse(format: DeckFormat, card: 'scryfall.Card', quantity: int) -> str:
     assert 0 < quantity
     match format:
         # 1x Ancient Cornucopia (big) 16 [Maybeboard{noDeck}{noPrice},Mana Advantage]
-        case DeckFormat.ARCHIDEKT: return f'{quantity}x {card.name} ({card.set}) {card.collector_number}'
+        case DeckFormat.ARCHIDEKT:
+            return f'{quantity}x {card.name} ({card.set}) {card.collector_number}'
         # Don't bother with all the CSV fields.
         # name, CMC, Type, Color, Set, Collector Number, Rarity, Color Category, status, Finish, maybeboard, image URL, image Back URL, tags, Notes, MTGO ID, Custom
         case DeckFormat.CUBECOBRA_CSV:
             s = io.StringIO()
             w = csv.writer(s)
-            w.writerow([card.name, '', '', '', card.set, card.collector_number] + [''] * 11)
+            w.writerow(
+                [card.name, '', '', '', card.set, card.collector_number] + [''] * 11
+            )
             return '\n'.join([s.getvalue()] * quantity)
-        case DeckFormat.DECKSTATS: return f'{quantity} [{card.set}#{card.collector_number}] {card.name}'
-        case DeckFormat.MOXFIELD: return f'{quantity} {card.name} ({card.set}) {card.collector_number}'
-        case DeckFormat.MPCFILL_XML: raise NotImplemented
-        case DeckFormat.MTGA: return f'{quantity}x {card.name} ({card.set}) {card.collector_number}'
-        case DeckFormat.MTGO: return f'{quantity} {card.name}'
-        case DeckFormat.SCRYFALL_JSON: return json.dumps({
-            "count": quantity,
-            "card_digest": {
-                "name": card.name,
-                "set": card.set,
-                "collector_number": card.collector_number,
-            }
-        })
-        case DeckFormat.SIMPLE: return '\n'.join([card.name] * quantity)
+        case DeckFormat.DECKSTATS:
+            return f'{quantity} [{card.set}#{card.collector_number}] {card.name}'
+        case DeckFormat.MOXFIELD:
+            return f'{quantity} {card.name} ({card.set}) {card.collector_number}'
+        case DeckFormat.MPCFILL_XML:
+            raise NotImplementedError
+        case DeckFormat.MTGA:
+            return f'{quantity}x {card.name} ({card.set}) {card.collector_number}'
+        case DeckFormat.MTGO:
+            return f'{quantity} {card.name}'
+        case DeckFormat.SCRYFALL_JSON:
+            return json.dumps(
+                {
+                    "count": quantity,
+                    "card_digest": {
+                        "name": card.name,
+                        "set": card.set,
+                        "collector_number": card.collector_number,
+                    },
+                }
+            )
+        case DeckFormat.SIMPLE:
+            return '\n'.join([card.name] * quantity)
         # URL is a pseudo format and cannot be unparsed. Use moxfield syntax.
-        case DeckFormat.URL: return unparse(DeckFormat.MOXFIELD, card, quantity)
+        case DeckFormat.URL:
+            return unparse(DeckFormat.MOXFIELD, card, quantity)

--- a/plugins/mtg/deck_formats.py
+++ b/plugins/mtg/deck_formats.py
@@ -297,7 +297,7 @@ def extract_mpcfill_card_ids(deck_text: str) -> set[str]:
     return card_ids
 
 
-def parse_mpcfill_xml(deck_text: str, fetch_card: FetchCard) -> DeckParse:
+def parse_mpcfill_xml(deck_text: str, handle_card: Callable[[int, str, str, str | None, str | None], None]) -> None:
     """
     Parse MPCFill XML and call fetch_card once per slot.
 
@@ -306,7 +306,6 @@ def parse_mpcfill_xml(deck_text: str, fetch_card: FetchCard) -> DeckParse:
 
     back_id and back_name will be None if the slot has no custom back.
     """
-    assert False, "MPCFill XML is not implemented"
     data = ET.fromstring(deck_text)
     fronts = data.find("fronts")
     backs = data.find("backs")
@@ -341,7 +340,7 @@ def parse_mpcfill_xml(deck_text: str, fetch_card: FetchCard) -> DeckParse:
                 slots[slot_idx]["back_id"] = card_id
                 slots[slot_idx]["back_name"] = name
 
-    # Call fetch_card once per slot (1-indexed for display and filenames)
+    # Call handle_card once per slot (1-indexed for display and filenames)
     for slot_idx, slot in enumerate(slots):
         slot_num = slot_idx + 1
         if slot["front_id"] is None:
@@ -425,7 +424,7 @@ def parse_deck(
         case DeckFormat.SCRYFALL_JSON:
             return parse_scryfall_json(deck_text, fetch_card)
         case DeckFormat.MPCFILL_XML:
-            return parse_mpcfill_xml(deck_text, fetch_card)
+            raise ValueError("`MPCFILL_XML` is not supported and has its own dispatcher")
         case DeckFormat.CUBECOBRA_CSV:
             return parse_cubecobra_csv(deck_text, fetch_card)
         case DeckFormat.URL:

--- a/plugins/mtg/fetch.py
+++ b/plugins/mtg/fetch.py
@@ -18,7 +18,9 @@ from plugins.mtg.common import MtgPrintedLanguage, partition, remove_nonalphanum
 from plugins.mtg.deck_formats import (
     DeckFormat,
     FetchCard,
+    extract_mpcfill_card_ids,
     parse_deck,
+    parse_mpcfill_xml,
     unparse,
 )
 from plugins.mtg.mpcfill import get_handle_card as mpc_get_handle_card
@@ -182,29 +184,35 @@ def cli(
             print(f'file not found: {deck_path}')
             raise click.Abort()
 
+    # MPC Fill XML is weird and doesn't follow all the other formats, which are all based on Scryfall.
+    # It more or less is its own ad-hoc thing.
+    # FUTURE WORK: Split `DeckFormat` into Scryfall formats and non-Scryfall formats.
     if deck_format == DeckFormat.MPCFILL_XML:
-        assert False, "MPCFill XML not supported"
-        # get_handle_card = mpc_get_handle_card(
-        #     front_directory,
-        #     double_sided_directory
-        # )
-        # prefetch_mpcfill(extract_mpcfill_card_ids(deck_text))
-    else:
-        fetch: FetchCard = functools.partial(
-            scryfall.fetch_card,
-            ignore_set_and_collector_number=ignore_set_and_collector_number,
-            ignore_sets=set(ignore_set),
-            ignore_ub=ignore_ub,
-            prefer_extra_art=prefer_extra_art,
-            prefer_langs=[
-                scryfall.Language.from_printed_lang(MtgPrintedLanguage(lang))
-                for lang in prefer_lang
-            ],
-            prefer_older_sets=prefer_older_sets,
-            prefer_sets=list(prefer_set),
-            prefer_showcase=prefer_showcase,
-            prefer_ub=prefer_ub,
+        if tokens:
+            print('ERROR - `--tokens` is incompatible w/ MPCFILL_XML deck format.')
+            raise click.Abort()
+
+        prefetch_mpcfill(extract_mpcfill_card_ids(deck_text))
+        parse_mpcfill_xml(
+            deck_text, mpc_get_handle_card(str(FRONT_DIR), str(DOUBLE_SIDED_DIR))
         )
+        return
+
+    fetch: FetchCard = functools.partial(
+        scryfall.fetch_card,
+        ignore_set_and_collector_number=ignore_set_and_collector_number,
+        ignore_sets=set(ignore_set),
+        ignore_ub=ignore_ub,
+        prefer_extra_art=prefer_extra_art,
+        prefer_langs=[
+            scryfall.Language.from_printed_lang(MtgPrintedLanguage(lang))
+            for lang in prefer_lang
+        ],
+        prefer_older_sets=prefer_older_sets,
+        prefer_sets=list(prefer_set),
+        prefer_showcase=prefer_showcase,
+        prefer_ub=prefer_ub,
+    )
 
     errors, deck = parse_deck(
         deck_text,

--- a/plugins/mtg/fetch.py
+++ b/plugins/mtg/fetch.py
@@ -1,57 +1,178 @@
+import functools
 import os
 import sys
+from collections import OrderedDict
+from pathlib import Path
+from typing import Iterable
+from uuid import UUID
 
 import click
 
 # Add parent directory to path to allow imports when run as a script
-REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
-sys.path.insert(0, REPO_ROOT)
+REPO_ROOT = Path(__file__).parent.parent.parent.absolute()
+sys.path.insert(0, str(REPO_ROOT))
 
-from plugins.mtg import remote
-from plugins.mtg.common import ScryfallLanguage
-from plugins.mtg.deck_formats import DeckFormat, parse_deck, extract_mpcfill_card_ids
-from plugins.mtg.scryfall import get_handle_card as scryfall_get_handle_card
-from plugins.mtg.mpcfill import get_handle_card as mpc_get_handle_card, prefetch_mpcfill
+
+from plugins.mtg import remote, scryfall
+from plugins.mtg.common import MtgPrintedLanguage, partition, remove_nonalphanumeric
+from plugins.mtg.deck_formats import (
+    DeckFormat,
+    FetchCard,
+    parse_deck,
+    unparse,
+)
+from plugins.mtg.mpcfill import get_handle_card as mpc_get_handle_card
+from plugins.mtg.mpcfill import prefetch_mpcfill
+from plugins.mtg.scryfall import Card, CardName
 from utilities import ensure_directory
 
-front_directory = os.path.join(REPO_ROOT, 'game', 'front')
-double_sided_directory = os.path.join(REPO_ROOT, 'game', 'double_sided')
+# CONSTANTS
+FRONT_DIR = REPO_ROOT / 'game' / 'front'
+DOUBLE_SIDED_DIR = REPO_ROOT / 'game' / 'double_sided'
 
+
+# Pairs single-faced cards together. Intended for grouping single-face tokens.
+# PRECONDITION: `forall x \in cards. x is single-faced`
+# FIXME: O(n^2)
+def _generate_paired_faces(
+    cards: Iterable[tuple[Card, int]],
+) -> list[tuple[CardName, scryfall.CardFaces]]:
+    card_queue: list[tuple[Card, scryfall.BytesPNG]] = []
+    for card, quantity in cards:
+        print(f"fetching image: {card.name} ({card.set}) {card.collector_number}")
+        faces = scryfall.fetch_faces(card)
+        assert (
+            faces.back is None
+        ), "PRECONDITION: single face tokens shouldn't have a back"
+        card_queue += [(card, faces.front)] * quantity
+
+    # process in reverse for cheap(er) pop
+    card_queue.reverse()
+    paired_with = set[UUID]()
+
+    def pick_pairing() -> tuple[Card, scryfall.BytesPNG] | None:
+        for i in range(1, len(card_queue)+1):
+            card, _ = card_queue[-i]
+            if card.id not in paired_with:
+                return card_queue.pop(-i)
+
+        return None
+
+    prev_front_card_id: UUID | None = None
+
+    def reset_pairings(front_card: Card):
+        nonlocal prev_front_card_id
+        prev_front_card_id = front_card.id
+        paired_with.clear()
+        # never pair with ourselves. prefer to have it blank.
+        paired_with.add(front_card.id)
+
+    deck_raw: list[tuple[CardName, scryfall.CardFaces]] = []
+    while card_queue:
+        front_card, front_face = card_queue.pop()
+        back_face: scryfall.BytesPNG | None = None
+
+        if prev_front_card_id is None or prev_front_card_id != front_card.id:
+            reset_pairings(front_card)
+
+        if (pair := pick_pairing()) is None:
+            # clear candidates & try again, but never pair with self
+            reset_pairings(front_card)
+            pair = pick_pairing()
+
+        if pair is not None:
+            back_card, back_face = pair
+            paired_with.add(back_card.id)
+            print(f"pairing tokens: `{front_card.name}` w/ `{back_card.name}`")
+        else:
+            print(f'NOTE: unpaired token `{front_card.name}`. maybe add another token?')
+
+        deck_raw.append(
+            (front_card.name, scryfall.CardFaces(front=front_face, back=back_face))
+        )
+
+    return deck_raw
+
+
+# n.b. `CardName` can be a partial lie due to token face pairing feature.
+def _generate_deck_faces(
+    deck: OrderedDict[Card, int],
+) -> list[tuple[CardName, scryfall.CardFaces]]:
+    boring, tokens = partition(
+        deck.items(), lambda kv: kv[0].layout != scryfall.Layout.TOKEN
+    )
+    deck_raw: list[tuple[CardName, scryfall.CardFaces]] = []
+
+    for card, quantity in boring:
+        print(f"fetching image: {card.name} ({card.set}) {card.collector_number}")
+        faces = scryfall.fetch_faces(card)
+        deck_raw += [(card.name, faces)] * quantity
+
+    deck_raw += _generate_paired_faces(tokens)
+    return deck_raw
+
+
+def report_tokens(format: DeckFormat, cards: Iterable[Card]):
+    tokens = OrderedDict[Card, int]()
+
+    for card in cards:
+        for token in scryfall.tokens(card):
+            tokens.setdefault(token, 0)
+            tokens[token] += 1
+
+    for token, quantity in tokens.items():
+        print(unparse(format, token, quantity))
+
+
+def generate_deck(deck: OrderedDict[Card, int]):
+    card_faces = _generate_deck_faces(deck)
+    for i, (name, faces) in enumerate(card_faces):
+        # FUTURE WORK: other img types?
+        def save_face(dir: Path, face: scryfall.BytesPNG | None):
+            if face is not None:
+                with open(dir / f'{i}_{remove_nonalphanumeric(name)}.png', 'wb') as f:
+                    f.write(face)
+
+        save_face(FRONT_DIR, faces.front)
+        save_face(DOUBLE_SIDED_DIR, faces.back)
+
+
+# fmt: off
 @click.command()
 @click.argument('deck_path')
-@click.argument('format', type=click.Choice([t.value for t in DeckFormat], case_sensitive=False))
+@click.argument('deck_format', type=click.Choice([t.value for t in DeckFormat], case_sensitive=False))
 @click.option('-i', '--ignore_set_and_collector_number', default=False, is_flag=True, show_default=True, help="Ignore provided sets and collector numbers when fetching cards.")
 @click.option('--prefer_older_sets', default=False, is_flag=True, show_default=True, help="Prefer fetching cards from older sets if sets are not provided.")
 @click.option('-s', '--prefer_set', multiple=True, help="Prefer fetching cards from a particular set(s) if sets are not provided. Use this option multiple times to specify multiple preferred sets.")
 @click.option('--ignore_set', multiple=True, help="Exclude a set from consideration when fetching cards. Use this option multiple times to exclude multiple sets.")
 @click.option('--prefer_showcase', default=False, is_flag=True, show_default=True, help="Prefer fetching cards with showcase treatment")
 @click.option('--prefer_extra_art', default=False, is_flag=True, show_default=True, help="Prefer fetching cards with full art, borderless, or extended art.")
-@click.option('--prefer_lang', multiple=True, type=click.Choice([lang.value for lang in ScryfallLanguage], case_sensitive=False), help="Preferred language for card images (printed code). Use multiple times for a priority list. Falls back to English if none are available.")
+@click.option('--prefer_lang', multiple=True, type=click.Choice([lang.value for lang in MtgPrintedLanguage], case_sensitive=False), help="Preferred language for card images (printed code). Use multiple times for a priority list. Falls back to English if none are available.")
 @click.option('--prefer_ub', default=False, is_flag=True, show_default=True, help="Prefer Universe Beyond printings when available.")
 @click.option('--ignore_ub', default=False, is_flag=True, show_default=True, help="Exclude Universe Beyond printings from consideration.")
 @click.option('--tokens', default=False, is_flag=True, show_default=True, help="Fetch related tokens when fetching cards")
+# fmt: on
+
 
 def cli(
     deck_path: str,
-    format: DeckFormat,
+    deck_format: DeckFormat,
+    *,
     ignore_set_and_collector_number: bool,
-
-    prefer_older_sets: bool,
-    prefer_set: tuple,
-    ignore_set: tuple,
-
-    prefer_showcase: bool,
-    prefer_extra_art: bool,
-
-    prefer_lang: tuple,
-    prefer_ub: bool,
+    ignore_set: Iterable[str],
     ignore_ub: bool,
-
+    prefer_extra_art: bool,
+    prefer_lang: Iterable[str],
+    prefer_older_sets: bool,
+    prefer_set: Iterable[str],
+    prefer_showcase: bool,
+    prefer_ub: bool,
     tokens: bool,
 ):
-    ensure_directory(front_directory)
-    ensure_directory(double_sided_directory)
-    if format == DeckFormat.URL:
+    ensure_directory(FRONT_DIR)
+    ensure_directory(DOUBLE_SIDED_DIR)
+
+    if deck_format == DeckFormat.URL:
         deck_text = deck_path
     else:
         if not os.path.isfile(deck_path):
@@ -61,42 +182,50 @@ def cli(
         with open(deck_path, 'r') as deck_file:
             deck_text = deck_file.read()
 
-    if format == DeckFormat.MPCFILL_XML:
-        get_handle_card = mpc_get_handle_card(
-            front_directory,
-            double_sided_directory
-        )
-        prefetch_mpcfill(extract_mpcfill_card_ids(deck_text))
+    if deck_format == DeckFormat.MPCFILL_XML:
+        assert False, "MPCFill XML not supported"
+        # get_handle_card = mpc_get_handle_card(
+        #     front_directory,
+        #     double_sided_directory
+        # )
+        # prefetch_mpcfill(extract_mpcfill_card_ids(deck_text))
     else:
-        get_handle_card = scryfall_get_handle_card(
-            ignore_set_and_collector_number,
-
-            prefer_older_sets,
-            prefer_set,
-            list(ignore_set),
-
-            prefer_showcase,
-            prefer_extra_art,
-            prefer_ub,
-            ignore_ub,
-
-            [ScryfallLanguage(lang) for lang in prefer_lang] or None,
-
-            tokens,
-
-            front_directory,
-            double_sided_directory,
+        fetch: FetchCard = functools.partial(
+            scryfall.fetch_card,
+            ignore_set_and_collector_number=ignore_set_and_collector_number,
+            ignore_sets=set(ignore_set),
+            ignore_ub=ignore_ub,
+            prefer_extra_art=prefer_extra_art,
+            prefer_langs=[
+                scryfall.Language.from_printed_lang(MtgPrintedLanguage(lang))
+                for lang in prefer_lang
+            ],
+            prefer_older_sets=prefer_older_sets,
+            prefer_sets=list(prefer_set),
+            prefer_showcase=prefer_showcase,
+            prefer_ub=prefer_ub,
         )
 
-    parse_deck(
+    errors, deck = parse_deck(
         deck_text,
-        format,
-        get_handle_card,
-        front_directory,
-        double_sided_directory,
+        deck_format,
+        fetch,
     )
+    if errors:
+        print('Errors occurred.')
+        for src, err in errors:
+            print(f"{src}\n: {err}")
 
-    remote.cache_trim()
+        raise click.Abort()  # if there were errors, stop.
+
+    if tokens:
+        report_tokens(deck_format, deck.keys())
+    else:
+        generate_deck(deck)
+
 
 if __name__ == '__main__':
-    cli()
+    try:
+        cli()
+    finally:
+        remote.cache_trim()

--- a/plugins/mtg/fetch.py
+++ b/plugins/mtg/fetch.py
@@ -175,12 +175,12 @@ def cli(
     if deck_format == DeckFormat.URL:
         deck_text = deck_path
     else:
-        if not os.path.isfile(deck_path):
-            print(f'{deck_path} is not a valid file.')
-            return
-
-        with open(deck_path, 'r') as deck_file:
-            deck_text = deck_file.read()
+        try:
+            with open(deck_path, 'r') as deck_file:
+                deck_text = deck_file.read()
+        except FileNotFoundError:
+            print(f'file not found: {deck_path}')
+            raise click.Abort()
 
     if deck_format == DeckFormat.MPCFILL_XML:
         assert False, "MPCFill XML not supported"

--- a/plugins/mtg/fetch.py
+++ b/plugins/mtg/fetch.py
@@ -7,6 +7,7 @@ import click
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 sys.path.insert(0, REPO_ROOT)
 
+from plugins.mtg import remote
 from plugins.mtg.common import ScryfallLanguage
 from plugins.mtg.deck_formats import DeckFormat, parse_deck, extract_mpcfill_card_ids
 from plugins.mtg.scryfall import get_handle_card as scryfall_get_handle_card
@@ -94,6 +95,8 @@ def cli(
         front_directory,
         double_sided_directory,
     )
+
+    remote.cache_trim()
 
 if __name__ == '__main__':
     cli()

--- a/plugins/mtg/fetch.py
+++ b/plugins/mtg/fetch.py
@@ -1,5 +1,4 @@
 import functools
-import os
 import sys
 from collections import OrderedDict
 from pathlib import Path
@@ -17,6 +16,7 @@ from plugins.mtg import remote, scryfall
 from plugins.mtg.common import MtgPrintedLanguage, partition, remove_nonalphanumeric
 from plugins.mtg.deck_formats import (
     DeckFormat,
+    DeckList,
     FetchCard,
     extract_mpcfill_card_ids,
     parse_deck,
@@ -37,10 +37,11 @@ DOUBLE_SIDED_DIR = REPO_ROOT / 'game' / 'double_sided'
 # PRECONDITION: `forall x \in cards. x is single-faced`
 # FIXME: O(n^2)
 def _generate_paired_faces(
-    cards: Iterable[tuple[Card, int]],
+    cards: DeckList,
 ) -> list[tuple[CardName, scryfall.CardFaces]]:
     card_queue: list[tuple[Card, scryfall.BytesPNG]] = []
     for card, quantity in cards:
+        assert 0 <= quantity
         print(f"fetching image: {card.name} ({card.set}) {card.collector_number}")
         faces = scryfall.fetch_faces(card)
         assert (
@@ -53,7 +54,7 @@ def _generate_paired_faces(
     paired_with = set[UUID]()
 
     def pick_pairing() -> tuple[Card, scryfall.BytesPNG] | None:
-        for i in range(1, len(card_queue)+1):
+        for i in range(1, len(card_queue) + 1):
             card, _ = card_queue[-i]
             if card.id not in paired_with:
                 return card_queue.pop(-i)
@@ -98,14 +99,13 @@ def _generate_paired_faces(
 
 # n.b. `CardName` can be a partial lie due to token face pairing feature.
 def _generate_deck_faces(
-    deck: OrderedDict[Card, int],
+    deck: DeckList,
 ) -> list[tuple[CardName, scryfall.CardFaces]]:
-    boring, tokens = partition(
-        deck.items(), lambda kv: kv[0].layout != scryfall.Layout.TOKEN
-    )
+    boring, tokens = partition(deck, lambda kv: kv[0].layout != scryfall.Layout.TOKEN)
     deck_raw: list[tuple[CardName, scryfall.CardFaces]] = []
 
     for card, quantity in boring:
+        assert 0 <= quantity
         print(f"fetching image: {card.name} ({card.set}) {card.collector_number}")
         faces = scryfall.fetch_faces(card)
         deck_raw += [(card.name, faces)] * quantity
@@ -115,7 +115,7 @@ def _generate_deck_faces(
 
 
 def report_tokens(format: DeckFormat, cards: Iterable[Card]):
-    tokens = OrderedDict[Card, int]()
+    tokens = OrderedDict[Card, int]() # gather by ID
 
     for card in cards:
         for token in scryfall.tokens(card):
@@ -126,7 +126,7 @@ def report_tokens(format: DeckFormat, cards: Iterable[Card]):
         print(unparse(format, token, quantity))
 
 
-def generate_deck(deck: OrderedDict[Card, int]):
+def generate_deck(deck: DeckList):
     card_faces = _generate_deck_faces(deck)
     for i, (name, faces) in enumerate(card_faces):
         # FUTURE WORK: other img types?
@@ -227,7 +227,7 @@ def cli(
         raise click.Abort()  # if there were errors, stop.
 
     if tokens:
-        report_tokens(deck_format, deck.keys())
+        report_tokens(deck_format, [card for (card, _) in deck])
     else:
         generate_deck(deck)
 

--- a/plugins/mtg/mpcfill.py
+++ b/plugins/mtg/mpcfill.py
@@ -22,12 +22,11 @@ from base64 import b64decode
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Set
 
-import requests
 from filetype.filetype import guess_extension
 
-from .common import remove_nonalphanumeric
+from plugins.mtg import remote
 
-session = requests.Session()
+from .common import remove_nonalphanumeric
 
 # Cache for fetched images: card_id -> decoded image bytes.
 # Populated by prefetch_mpcfill() and read by get_cached_image().
@@ -38,12 +37,11 @@ _image_cache: dict[str, bytes] = {}
 # up to 8 simultaneous downloads.
 MAX_WORKERS = 8
 
-
+@remote.memo
 def request_mpcfill(card_id: str) -> bytes:
     """Fetch a single card image from MPCFill API and return decoded bytes."""
     base_url = "https://script.google.com/macros/s/AKfycbw8laScKBfxda2Wb0g63gkYDBdy8NWNxINoC4xDOwnCQ3JMFdruam1MdmNmN4wI5k4/exec?id="
-    r = session.get(base_url + card_id, headers={"user-agent": "silhouette-card-maker/0.1", "accept": "*/*"})
-    r.raise_for_status()
+    r = remote.get(base_url + card_id)
     return b64decode(r.content)
 
 

--- a/plugins/mtg/remote.py
+++ b/plugins/mtg/remote.py
@@ -1,0 +1,68 @@
+import pathlib
+from datetime import timedelta
+import time
+from typing import Any, Callable
+
+import joblib
+import requests
+
+# CONFIGURABLE
+# cmdr deck is ~100mb, so store the last two
+_CACHE_SIZE_MAX = 256 * 1024 * 1024
+# assume the data does not change that often and we can keep the last day
+_CACHE_AGE_MAX = timedelta(days=1)
+_GET_RETRIES = 3
+_GET_RETRY_DELAY = timedelta(seconds=30)
+
+# CONSTANTS
+_HTTP_RATE_LIMITED = 429
+_CACHE_DIR = pathlib.Path(__file__).parent / ".cache-remote"
+_CACHE_DIR.mkdir(exist_ok=True)
+_SCRYFALL_RETRY_DELAY_MIN = timedelta(seconds=30)
+
+
+_GET_HEADERS = {
+    'user-agent': 'silhouette-card-maker/0.1',
+    'accept': '*/*',
+}
+
+# STATE
+_cache = joblib.Memory(
+    # Don't bother with compression. Majority of it is images and those are incompressible.
+    location=_CACHE_DIR,
+    verbose=0,
+)
+_session = requests.Session()
+
+# INVARIANTS
+assert 0 < _CACHE_SIZE_MAX
+assert timedelta() < _CACHE_AGE_MAX
+assert 0 < _GET_RETRIES
+assert _SCRYFALL_RETRY_DELAY_MIN <= _GET_RETRY_DELAY, "Scryfall requires at least 30s between retries"
+
+def memo(func: Callable | None = None):
+    if func is None: # no partial args at this time, just give a plain wrapper
+      return lambda func: memo(func)
+
+    return _cache.cache(func)
+
+def get(query: str, params: dict[str, Any] | None = None) -> requests.Response:
+    for i in range(_GET_RETRIES):
+        r = _session.get(query, params=params, headers = _GET_HEADERS)
+        # Rate limit check - Scryfall requires 30 second wait per their documentation
+        if r.status_code != _HTTP_RATE_LIMITED:
+            r.raise_for_status()
+            return r
+
+        print(f"Hit rate limit ({_HTTP_RATE_LIMITED}), waiting {_GET_RETRY_DELAY} seconds before retry {i + 1}/{_GET_RETRIES}...")
+        time.sleep(_GET_RETRY_DELAY.total_seconds())
+
+    assert isinstance(r, requests.Response)
+    print(f"Warning: Hit rate limit {_GET_RETRIES} times for {query}, giving up.")
+    raise requests.exceptions.HTTPError(f"Max retries ({_GET_RETRIES}) exceeded query: {query}", response=r)
+
+def cache_trim():
+    _cache.reduce_size(
+        bytes_limit=_CACHE_SIZE_MAX,
+        age_limit=_CACHE_AGE_MAX,
+    )

--- a/plugins/mtg/scryfall.py
+++ b/plugins/mtg/scryfall.py
@@ -1,43 +1,308 @@
-import os
+import enum
 import time
+from dataclasses import dataclass
+from datetime import datetime
 from io import BytesIO
-from typing import List, Optional, Tuple
+from typing import Any, Callable, Iterable
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+from uuid import UUID
 
 import requests
 from PIL import Image
+from serde import field, serde
+from serde.json import from_json
 
-from . import remote
-from .common import ScryfallLanguage, remove_nonalphanumeric, to_scryfall_api_lang
+from plugins.mtg import remote
+from plugins.mtg.common import MtgPrintedLanguage, partition
 
-double_sided_layouts = ['transform', 'modal_dfc', 'double_faced_token', 'reversible_card', 'meld']
+type _URI = str
+type BytesPNG = bytes
 
-def append_search_filter(uri: str, filter_term: str) -> str:
+type CardName = str
+type SetCode = str
+type CollectorNumber = str  # n.b. NOT a number. arbitrary string.
+
+
+# Last updated: 2026-07-18
+class BorderColour(enum.StrEnum):
+    BLACK = enum.auto()
+    WHITE = enum.auto()
+    BORDERLESS = enum.auto()
+    YELLOW = enum.auto()
+    SILVER = enum.auto()
+    GOLD = enum.auto()
+
+
+# Last updated: 2026-07-18
+class FrameEffect(enum.StrEnum):
+    LEGENDARY = enum.auto()
+    MIRACLE = enum.auto()
+    ENCHANTMENT = enum.auto()
+    DRAFT = enum.auto()
+    DEVOID = enum.auto()
+    TOMBSTONE = enum.auto()
+    COLORSHIFTED = enum.auto()
+    INVERTED = enum.auto()
+    SUNMOONDFC = enum.auto()
+    COMPASSLANDDFC = enum.auto()
+    ORIGINPWDFC = enum.auto()
+    MOONELDRAZIDFC = enum.auto()
+    WAXINGANDWANINGMOONDFC = enum.auto()
+    SHOWCASE = enum.auto()
+    EXTENDEDART = enum.auto()
+    COMPANION = enum.auto()
+    ETCHED = enum.auto()
+    SNOW = enum.auto()
+    LESSON = enum.auto()
+    SHATTEREDGLASS = enum.auto()
+    CONVERTDFC = enum.auto()
+    FANDFC = enum.auto()
+    UPSIDEDOWNDFC = enum.auto()
+    SPREE = enum.auto()
+
+
+# Last updated: 2026-07-18
+class ImageStatus(enum.StrEnum):
+    MISSING = enum.auto()
+    PLACEHOLDER = enum.auto()
+    LOWRES = enum.auto()
+    HIGHRES_SCAN = enum.auto()  # sic
+
+
+# Last updated: 2026-07-18
+class Language(enum.StrEnum):
+    ENGLISH = "en"
+    SPANISH = "es"
+    FRENCH = "fr"
+    GERMAN = "de"
+    ITALIAN = "it"
+    PORTUGUESE = "pt"
+    JAPANESE = "ja"
+    KOREAN = "ko"
+    RUSSIAN = "ru"
+    SIMPLIFIED_CHINESE = "zhs"
+    TRADITIONAL_CHINESE = "zht"
+    ANCIENT_GREEK = "grc"
+    PHYREXIAN = "ph"
+
+    @staticmethod
+    def from_printed_lang(x: MtgPrintedLanguage) -> 'Language':
+        match x:
+            case MtgPrintedLanguage.ENGLISH:
+                return Language.ENGLISH
+            case MtgPrintedLanguage.SPANISH:
+                return Language.SPANISH
+            case MtgPrintedLanguage.FRENCH:
+                return Language.FRENCH
+            case MtgPrintedLanguage.GERMAN:
+                return Language.GERMAN
+            case MtgPrintedLanguage.ITALIAN:
+                return Language.ITALIAN
+            case MtgPrintedLanguage.PORTUGUESE:
+                return Language.PORTUGUESE
+            case MtgPrintedLanguage.JAPANESE:
+                return Language.JAPANESE
+            case MtgPrintedLanguage.KOREAN:
+                return Language.KOREAN
+            case MtgPrintedLanguage.RUSSIAN:
+                return Language.RUSSIAN
+            case MtgPrintedLanguage.SIMPLIFIED_CHINESE:
+                return Language.SIMPLIFIED_CHINESE
+            case MtgPrintedLanguage.TRADITIONAL_CHINESE:
+                return Language.TRADITIONAL_CHINESE
+            case MtgPrintedLanguage.ANCIENT_GREEK:
+                return Language.ANCIENT_GREEK
+            case MtgPrintedLanguage.PHYREXIAN:
+                return Language.PHYREXIAN
+
+
+# Last updated: 2026-07-18
+# https://scryfall.com/docs/api/layouts
+class Layout(enum.StrEnum):
+    ADVENTURE = enum.auto()
+    ART_SERIES = enum.auto()
+    AUGMENT = enum.auto()
+    BATTLE = enum.auto()
+    CASE = enum.auto()
+    CLASS = enum.auto()
+    DOUBLE_FACED_TOKEN = enum.auto()
+    EMBLEM = enum.auto()
+    FLIP = enum.auto()
+    HOST = enum.auto()
+    LEVELER = enum.auto()
+    MELD = enum.auto()
+    MODAL_DFC = enum.auto()
+    MUTATE = enum.auto()
+    NORMAL = enum.auto()
+    PLANAR = enum.auto()
+    PREPARE = enum.auto()
+    PROTOTYPE = enum.auto()
+    REVERSIBLE_CARD = enum.auto()
+    SAGA = enum.auto()
+    SCHEME = enum.auto()
+    SPLIT = enum.auto()
+    TOKEN = enum.auto()
+    TRANSFORM = enum.auto()
+    VANGUARD = enum.auto()
+
+    @property
+    def double_sided(self) -> bool:
+        match self:
+            case self.ART_SERIES:
+                return True
+            case self.DOUBLE_FACED_TOKEN:
+                return True
+            case self.MELD:
+                return True
+            case self.MODAL_DFC:
+                return True
+            case self.REVERSIBLE_CARD:
+                return True
+            case self.TRANSFORM:
+                return True
+            case _:
+                return False
+
+
+# Last updated: 2026-07-18
+# https://scryfall.com/docs/api/cards
+class Rarity(enum.StrEnum):
+    BONUS = enum.auto()
+    COMMON = enum.auto()
+    MYTHIC = enum.auto()
+    RARE = enum.auto()
+    SPECIAL = enum.auto()
+    UNCOMMON = enum.auto()
+
+
+# Last updated: 2026-07-18
+# Subset of properties.
+@serde
+class Face:
+    name: str
+    image_uris: dict[str, _URI] = field(
+        default_factory=dict
+    )  # type not defined by spec
+    layout: Layout | None = None  # defined IIF reversible
+    object: str = 'card_face'  # must be `card_face`
+
+
+# Last updated: 2026-07-18
+@serde
+class RelatedCardObject:
+    class Component(enum.StrEnum):
+        COMBO_PIECE = enum.auto()
+        MELD_PART = enum.auto()
+        MELD_RESULT = enum.auto()
+        TOKEN = enum.auto()
+
+    component: Component
+    id: UUID
+    name: str
+    type_line: str
+    uri: _URI
+    object: str = 'related_card'  # must be `related_card`
+
+
+# Last updated: 2026-07-18
+# Subset of properties.
+# https://scryfall.com/docs/api/cards
+@serde
+class Card:
+    booster: bool
+    collector_number: CollectorNumber  # not a number, despite the name
+    digital: bool
+    full_art: bool
+    border_color: BorderColour
+    id: UUID  # actually a UUID
+    image_status: ImageStatus
+    lang: Language
+    layout: Layout
+    name: CardName
+    nonfoil: bool
+    oversized: bool
+    prints_search_uri: _URI
+    promo: bool
+    rarity: Rarity
+    released_at: datetime
+    reprint: bool
+    rulings_uri: _URI
+    scryfall_set_uri: _URI
+    scryfall_uri: _URI
+    set_id: UUID
+    set_name: str
+    set_type: str
+    set_uri: _URI
+    set: SetCode
+    story_spotlight: bool
+    textless: bool
+    uri: _URI
+    variation: bool  # implies `variation_of` TODO: enforce
+    all_parts: list[RelatedCardObject] = field(default_factory=list)
+    card_back_id: UUID | None = None  # SPEC ERROR: not always available
+    card_faces: list[Face] = field(default_factory=list)
+    frame_effects: list[FrameEffect] = field(default_factory=list)
+    image_uris: dict[str, _URI] = field(
+        default_factory=dict
+    )  # type not defined by spec
+    object: str = 'card'  # must be `card`
+    oracle_id: UUID | None = None
+    resource_id: str | None = None
+    variation_of: UUID | None = None  # implies `variation = true` TODO: enforce
+
+    # ASSUME: `id` is indeed a PK of the data
+    def __hash__(self) -> int:
+        return hash(self.id)
+
+
+# API internal stuff. Incomplete, doesn't directly handle the error type variant.
+@serde
+class _SearchResponse:
+    data: list[Card]
+
+
+def _append_search_filter(uri: str, filter_term: str) -> str:
     parsed = urlparse(uri)
     params = parse_qs(parsed.query, keep_blank_values=True)
     q_val = params.get('q', [''])[0]
     params['q'] = [q_val + ' ' + filter_term]
     return urlunparse(parsed._replace(query=urlencode(params, doseq=True)))
 
-def fetch_printings(prints_search_uri: str, prefer_ub: Optional[bool], name: str) -> List:
+
+def _fetch_printings(
+    name: str, prints_search_uri: _URI, prefer_ub: bool | None
+) -> list[Card]:
+    xs: list[Card] = []
     if prefer_ub is not None:
         filter_term = 'is:ub' if prefer_ub else '-is:ub'
-        filtered_uri = append_search_filter(prints_search_uri, filter_term)
+        filtered_uri = _append_search_filter(prints_search_uri, filter_term)
+
         try:
-            filtered = request_scryfall(filtered_uri).json().get('data', [])
+            xs = from_json(
+                _SearchResponse, _request_scryfall(filtered_uri).content
+            ).data
         except requests.exceptions.HTTPError:
-            filtered = []
-        if filtered:
-            return filtered
-        label = 'No Universe Beyond' if prefer_ub else 'All'
-        flag = '--prefer_ub' if prefer_ub else '--ignore_ub'
-        print(f'{label} printings for "{name}" are Universe Beyond. Ignoring {flag}.')
-    return request_scryfall(prints_search_uri).json()['data']
+            xs = []
+
+        if not xs:
+            label = 'No Universe Beyond' if prefer_ub else 'All'
+            flag = '--prefer_ub' if prefer_ub else '--ignore_ub'
+            print(
+                f'{label} printings for "{name}" are Universe Beyond. Ignoring {flag}.'
+            )
+
+    if not xs:
+        xs = from_json(
+            _SearchResponse, _request_scryfall(prints_search_uri).content
+        ).data
+
+    return xs
+
 
 @remote.memo
-def request_scryfall(
+def _request_scryfall(
     query: str,
-    params: dict = None,
+    params: dict[str, Any] | None = None,
 ) -> requests.Response:
     r = remote.get(query, params)
 
@@ -46,54 +311,46 @@ def request_scryfall(
     # Note: Direct image downloads from *.scryfall.io CDN have NO rate limits
 
     if "cards/search" in query or "cards/named" in query:
-        time.sleep(0.5)   # Search/named endpoints: 2 requests/second (500ms delay)
+        time.sleep(0.5)  # Search/named endpoints: 2 requests/second (500ms delay)
     elif 'api.scryfall.com' in query:
         time.sleep(0.1)  # All other API methods: 10 requests/second (100ms delay)
     # else: No rate limiting needed for direct image downloads from *.scryfall.io CDN
 
     return r
 
-def save_card_art_copies(data: bytes, output_dir: str, index: int, clean_card_name: str, quantity: int) -> None:
-    for counter in range(quantity):
-        image_path = os.path.join(output_dir, f'{index}{clean_card_name}{counter + 1}.png')
-        with open(image_path, 'wb') as f:
-            f.write(data)
 
-def fetch_meld_back(
-    index: int,
-    quantity: int,
+def _fetch_meld_back(card: Card) -> BytesPNG | None:
+    def parts(component: RelatedCardObject.Component):
+        return [part for part in card.all_parts if part.component == component]
 
-    clean_card_name: str,
-    card_name: str,
-    all_parts: List,
-
-    double_sided_dir: str
-) -> None:
-    meld_result = None
-    meld_parts = []
-    for part in all_parts:
-        if part['component'] == 'meld_result':
-            meld_result = part
-        elif part['component'] == 'meld_part':
-            meld_parts.append(part)
-
-    if meld_result is None or len(meld_parts) != 2:
-        return
+    meld_results = parts(RelatedCardObject.Component.MELD_RESULT)
+    meld_parts = parts(RelatedCardObject.Component.MELD_PART)
+    # FUTURE WORK: move this validation to post-validate on `Card`
+    assert (
+        len(meld_results) == 1
+    ), "malformed meld card: does not have exactly 1 `meld_result`"
+    assert (
+        len(meld_parts) == 2
+    ), "malformed meld card: does not have exactly 2 `meld_part`s"
+    meld_result = meld_results[0]
 
     # Don't fetch back if this card is the meld result itself
-    if meld_result['name'] == card_name:
-        return
+    if meld_result.name == card.name:
+        return None
 
     # Find the 0-based index of this card within meld_parts (the two non-result halves).
     # Scryfall lists meld parts in a consistent order; index 0 = top half, index 1 = bottom half.
     # next() returns the first index i where the part's name matches, or -1 as the default.
-    meld_part_index = next((i for i, p in enumerate(meld_parts) if p['name'] == card_name), -1)
-    if meld_part_index == -1:
-        return
+    meld_part_index = next(
+        (i for i, p in enumerate(meld_parts) if p.name == card.name), -1
+    )
+    assert meld_part_index != -1, "malformed meld card: no meld parts w/ card's name"
 
     # Fetch the meld result card info; the PNG URL is in the response, no second request needed
-    meld_result_json = request_scryfall(meld_result['uri']).json()
-    meld_result_image_data = request_scryfall(meld_result_json['image_uris']['png']).content
+    meld_result_json = from_json(Card, _request_scryfall(meld_result.uri).content)
+    meld_result_image_data: bytes = _request_scryfall(
+        meld_result_json.image_uris['png']
+    ).content
 
     # Split the meld result image into top/bottom halves
     img = Image.open(BytesIO(meld_result_image_data))
@@ -113,305 +370,212 @@ def fetch_meld_back(
     # Resize to full card dimensions
     resized = cropped.resize((width, height), Image.LANCZOS)
 
-    # Save image based on quantity
-    for counter in range(quantity):
-        image_path = os.path.join(double_sided_dir, f'{str(index)}{clean_card_name}{str(counter + 1)}.png')
-        resized.save(image_path)
+    output = BytesIO()
+    resized.save(output, format="png")
+    return output.getvalue()
 
-def build_image_url(card_set: str, card_collector_number: str, prefer_lang: ScryfallLanguage = None) -> str:
-    if prefer_lang and prefer_lang != ScryfallLanguage.ENGLISH:
-        api_lang = to_scryfall_api_lang(prefer_lang)
-        return f'https://api.scryfall.com/cards/{card_set}/{card_collector_number}/{api_lang}?format=image&version=png'
+
+def _build_image_url(
+    card_set: SetCode, card_collector_number: CollectorNumber, prefer_lang: Language
+) -> str:
+    if prefer_lang != Language.ENGLISH:
+        return f'https://api.scryfall.com/cards/{card_set}/{card_collector_number}/{prefer_lang.value}?format=image&version=png'
+
     return f'https://api.scryfall.com/cards/{card_set}/{card_collector_number}/?format=image&version=png'
 
-def fetch_image(card_set: str, card_collector_number: str, prefer_langs: List[ScryfallLanguage] = None, face: str = None) -> bytes:
-    langs_to_try = list(prefer_langs) if prefer_langs else []
-    if not langs_to_try or langs_to_try[-1] != ScryfallLanguage.ENGLISH:
-        langs_to_try.append(ScryfallLanguage.ENGLISH)
 
-    last_error = None
-    for i, lang in enumerate(langs_to_try):
-        url = build_image_url(card_set, card_collector_number, lang)
-        if face:
-            url = f'{url}&face={face}'
-        try:
-            return request_scryfall(url).content
-        except requests.exceptions.HTTPError as e:
-            if e.response is None or e.response.status_code != 404:
-                raise
-            last_error = e
-            if i < len(langs_to_try) - 1:
-                next_lang = langs_to_try[i + 1]
-                print(f'Language "{lang.value}" not available for set code: {card_set} and collector number: {card_collector_number}, falling back to "{next_lang.value}".')
-    raise last_error
-
-def fetch_card_art(
-    index: int,
-    quantity: int,
-
-    clean_card_name: str,
-    card_set: int,
-    card_collector_number: int,
-    layout: str,
-
-    all_parts: List = None,
-    card_name: str = None,
-    prefer_langs: List[ScryfallLanguage] = None,
-
-    front_img_dir: str = None,
-    double_sided_dir: str = None,
-) -> None:
-    # Query for the front side
-    card_art = fetch_image(card_set, card_collector_number, prefer_langs)
-    if card_art is not None:
-        save_card_art_copies(card_art, front_img_dir, index, clean_card_name, quantity)
-
-    # Get backside of card, if it exists
-    if layout in double_sided_layouts:
-        if layout == 'meld':
-            if all_parts and card_name:
-                fetch_meld_back(index, quantity, clean_card_name, card_name, all_parts, double_sided_dir)
-        else:
-            card_art = fetch_image(card_set, card_collector_number, prefer_langs, face='back')
-            if card_art is not None:
-                save_card_art_copies(card_art, double_sided_dir, index, clean_card_name, quantity)
-
-def partition_printings(printings: List, condition: List) -> Tuple[List, List]:
-    matches = []
-    non_matches = []
-    for card in printings:
-        (matches if condition(card) else non_matches).append(card)
-    return matches, non_matches
-
-def progressive_filtering(printings: List, filters):
-    pool = printings
-    leftovers = []
+def _progressive_filtering(
+    printings: Iterable[Card], filters: Iterable[Callable[[Card], bool]]
+) -> list[Card]:
+    pool = list(printings)
+    leftovers: list[Card] = []
 
     for condition in filters:
-        matched, not_matched = partition_printings(pool, condition)
+        matched, not_matched = partition(pool, condition)
         leftovers = not_matched + leftovers
         pool = matched or pool  # Only narrow if we have any matches
 
     return pool + leftovers
 
-def filtering(printings: List, filters):
-    pool = printings
 
-    for condition in filters:
-        matched, _ = partition_printings(pool, condition)
-        pool = matched
+def fetch_image(
+    card_set: SetCode,
+    collector_number: CollectorNumber,
+    prefer_langs: list[Language],
+    face: str | None = None,
+) -> bytes | None:
+    langs_to_try = list(prefer_langs)
+    if not langs_to_try or langs_to_try[-1] != Language.ENGLISH:
+        langs_to_try.append(Language.ENGLISH)
 
-    return pool
+    last_error: Exception | None = None
+    for lang in langs_to_try:
+        url = _build_image_url(card_set, collector_number, lang)
+        if face:
+            url = f'{url}&face={face}'
 
-def fetch_card(
-    index: int,
-    quantity: int,
-
-    card_set: str,
-    card_collector_number: str,
-    ignore_set_and_collector_number: bool,
-
-    name: str,
-
-    prefer_older_sets: bool,
-    prefer_sets: List[str],
-    ignore_sets: List[str],
-
-    prefer_showcase: bool,
-    prefer_extra_art: bool,
-    prefer_ub: bool,
-    ignore_ub: bool,
-
-    prefer_langs: List[ScryfallLanguage],
-
-    tokens: bool,
-
-    front_img_dir: str,
-    double_sided_dir: str,
-):
-    # Query based on card set and card collector number if provided
-    if not ignore_set_and_collector_number and card_set != "" and card_collector_number != "":
-        card_info_query = f"https://api.scryfall.com/cards/{card_set.lower()}/{card_collector_number}"
-
-        # Query for card info
-        card_json = request_scryfall(card_info_query).json()
-
-        fetch_card_art(
-            index,
-            quantity,
-            remove_nonalphanumeric(card_json['name']),
-            card_json['set'],
-            card_json['collector_number'],
-            card_json['layout'],
-            card_json.get('all_parts'),
-            card_json['name'],
-            prefer_langs,
-            front_img_dir,
-            double_sided_dir,
-        )
-
-        # Fetch tokens
-        if tokens:
-            if all_parts := card_json.get("all_parts"):
-                for related in all_parts:
-                    if related["component"] == "token":
-                        card_info_query = related["uri"]
-                        card_json = request_scryfall(card_info_query).json()
-                        fetch_card_art(
-                            index,
-                            quantity,
-                            # Offsprint tokens have the same name as the card, so append _token to differentiate
-                            f'{remove_nonalphanumeric(related["name"])}_token',
-                            card_json["set"],
-                            card_json["collector_number"],
-                            card_json["layout"],
-                            prefer_langs=prefer_langs,
-                            front_img_dir=front_img_dir,
-                            double_sided_dir=double_sided_dir,
-                        )
-
-    # Query based on card name
-    else:
-        if name == "":
-            raise Exception()
-
-        # Query for card info (use params= for correct URL encoding of accented/special chars)
         try:
-            card_json = request_scryfall('https://api.scryfall.com/cards/named', params={'exact': name}).json()
+            return _request_scryfall(url).content
         except requests.exceptions.HTTPError as e:
             if e.response is None or e.response.status_code != 404:
                 raise
-            # Fall back to flavor name search (e.g. Godzilla series, convention promos)
-            search_json = request_scryfall('https://api.scryfall.com/cards/search', params={'q': f'flavor_name:"{name}"', 'unique': 'cards'}).json()
-            if not search_json.get('data'):
-                raise
-            card_json = search_json['data'][0]
-            print(f'Found by flavor name: {card_json["name"]}')
 
-        # Filter out symbols from card names for use in filenames
-        clean_card_name = remove_nonalphanumeric(name)
+            last_error = e
+            print(
+                f'Language "{lang.value}" not available for set code: {card_set} and collector number: {collector_number}.'
+            )
 
-        set = card_json["set"]
-        collector_number = card_json["collector_number"]
+    assert last_error is not None
+    raise last_error
 
-        # Filter over available printings when any filtering option is set
-        needs_filtering = prefer_langs or prefer_older_sets or prefer_sets or ignore_sets or prefer_showcase or prefer_extra_art or prefer_ub or ignore_ub
-        if needs_filtering:
-            ub_preference = True if prefer_ub else (False if ignore_ub else None)
-            card_printings = fetch_printings(card_json['prints_search_uri'], ub_preference, name)
 
-            if ignore_sets:
-                remaining = [c for c in card_printings if c['set'] not in ignore_sets]
-                if not remaining:
-                    print(f'All printings for "{name}" are in ignored sets. Ignoring --ignore_set.')
-                else:
-                    card_printings = remaining
+def _fetch_face(card: Card, *, face: str | None = None) -> BytesPNG:
+    url = _build_image_url(card.set, card.collector_number, card.lang)
+    if face:
+        url = f'{url}&face={face}'
+    return _request_scryfall(url).content
 
-            if prefer_older_sets:
-                card_printings.reverse()
 
-            # Define filters in order of preference.
-            # Language filters are applied FIRST to ensure we only consider printings available in the preferred language.
-            # This prevents situations where full-art/showcase versions are selected but only available in English.
-            # prefer_langs is an ordered list: each language gets its own filter so earlier languages rank higher.
-            # prefer_sets is an ordered list: each set gets its own filter so earlier sets rank higher.
-            filters = [
-                *[lambda c, lang=lang: c['lang'] == to_scryfall_api_lang(lang) for lang in prefer_langs or []],
-                lambda c: c['nonfoil'],
-                lambda c: not c['digital'],
-                lambda c: not c['promo'],
-                *[lambda c, s=s: c['set'] == s for s in prefer_sets],
-                lambda c: not prefer_showcase ^ ('frame_effects' in c and 'showcase' in c['frame_effects']),
-                lambda c: not prefer_extra_art ^ (c['full_art'] or c['border_color'] == "borderless" or ('frame_effects' in c and 'extendedart' in c['frame_effects']))
-            ]
+@dataclass(frozen=True)
+class CardFaces:
+    front: BytesPNG
+    back: BytesPNG | None = None  # not all cards are double sided
 
-            filtered_printings = progressive_filtering(card_printings, filters)
 
-            if len(filtered_printings) == 0:
-                print(f'No printings found for "{name}" with preferred options. Using default instead.')
-            else:
-                best_print = filtered_printings[0]
-                set = best_print["set"]
-                collector_number = best_print["collector_number"]
+def fetch_faces(
+    card: Card,
+) -> CardFaces:
+    if card.layout == Layout.MELD:  # meld is double-sided but has a weird layout.
+        back = _fetch_meld_back(card)
+    elif card.layout.double_sided:  # non-meld double-sided are simple to handle
+        back = _fetch_face(card, face='back')
+    else:
+        back = None
 
-        fetch_card_art(
-            index,
-            quantity,
-            clean_card_name,
-            set,
-            collector_number,
-            card_json['layout'],
-            card_json.get('all_parts'),
-            card_json['name'],
-            prefer_langs,
-            front_img_dir,
-            double_sided_dir,
+    return CardFaces(front=_fetch_face(card), back=back)
+
+
+def tokens(card: Card) -> list[Card]:
+    return [
+        from_json(Card, _request_scryfall(r.uri).content)
+        for r in card.all_parts
+        if r.component == RelatedCardObject.Component.TOKEN
+    ]
+
+
+def fetch_card(
+    name: CardName,
+    set_code: SetCode | None = None,
+    collector_number: CollectorNumber | None = None,
+    *,
+    ignore_set_and_collector_number: bool = False,
+    ignore_sets: set[str] = set(),
+    ignore_ub: bool = False,
+    prefer_extra_art: bool = False,
+    prefer_langs: list[Language] = [],
+    prefer_older_sets: bool = False,
+    prefer_sets: list[str] = [],
+    prefer_showcase: bool = False,
+    prefer_ub: bool = False,
+) -> Card:
+    if name == "":
+        raise ValueError("card name cannot be empty")
+
+    # Define filters in order of preference.
+    # Language filters are applied FIRST to ensure we only consider printings available in the preferred language.
+    # This prevents situations where full-art/showcase versions are selected but only available in English.
+    # prefer_langs is an ordered list: each language gets its own filter so earlier languages rank higher.
+    # prefer_sets is an ordered list: each set gets its own filter so earlier sets rank higher.
+    prefer_filters: list[Callable[[Card], bool]] = [
+        *[(lambda c, lang=lang: c.lang == lang) for lang in prefer_langs],
+        lambda c: c.nonfoil,
+        lambda c: not c.digital,
+        lambda c: not c.promo,
+        *[(lambda c, s=s: c.set == s) for s in prefer_sets],
+        lambda c: not prefer_showcase ^ (FrameEffect.SHOWCASE in c.frame_effects),
+        lambda c: not prefer_extra_art
+        ^ (
+            c.full_art
+            or c.border_color == "borderless"
+            or FrameEffect.EXTENDEDART in c.frame_effects
+        ),
+    ]
+
+    # Query based on card set and card collector number if provided
+    if (
+        not ignore_set_and_collector_number
+        and set_code is not None
+        and collector_number is not None
+    ):
+        return from_json(
+            Card,
+            _request_scryfall(
+                f"https://api.scryfall.com/cards/{set_code.lower()}/{collector_number}"
+            ).content,
         )
 
-        # Fetch tokens
-        if tokens:
-            if all_parts := card_json.get("all_parts"):
-                for related in all_parts:
-                    if related["component"] == "token":
-                        card_info_query = related["uri"]
-                        card_json = request_scryfall(card_info_query).json()
-                        fetch_card_art(
-                            index,
-                            quantity,
-                            # Offsprint tokens have the same name as the card, so append _token to differentiate
-                            f'{remove_nonalphanumeric(related["name"])}_token',
-                            card_json["set"],
-                            card_json["collector_number"],
-                            card_json["layout"],
-                            prefer_langs=prefer_langs,
-                            front_img_dir=front_img_dir,
-                            double_sided_dir=double_sided_dir,
-                        )
+    # Don't have (or don't want to use) set/collector-id to pick exact card.
+    # Look for the best match instead.
 
-def get_handle_card(
-    ignore_set_and_collector_number: bool,
-
-    prefer_older_sets: bool,
-    prefer_sets: List[str],
-    ignore_sets: List[str],
-
-    prefer_showcase: bool,
-    prefer_extra_art: bool,
-    prefer_ub: bool,
-    ignore_ub: bool,
-
-    prefer_langs: List[ScryfallLanguage],
-
-    tokens: bool,
-
-    front_img_dir: str,
-    double_sided_dir: str,
-):
-    def configured_fetch_card(index: int, name: str, card_set: str = None, card_collector_number: int = None, quantity: int = 1):
-        fetch_card(
-            index,
-            quantity,
-
-            card_set,
-            card_collector_number,
-            ignore_set_and_collector_number,
-
-            name,
-
-            prefer_older_sets,
-            prefer_sets,
-            ignore_sets,
-
-            prefer_showcase,
-            prefer_extra_art,
-            prefer_ub,
-            ignore_ub,
-
-            prefer_langs,
-
-            tokens,
-
-            front_img_dir,
-            double_sided_dir,
+    # Start by name.
+    try:
+        card = from_json(
+            Card,
+            _request_scryfall(
+                'https://api.scryfall.com/cards/named', params={'exact': name}
+            ).content,
         )
-    return configured_fetch_card
+    except requests.exceptions.HTTPError as e:
+        if e.response is None or e.response.status_code != 404:
+            raise  # something went wrong with the query
+
+        # Fall back to flavor name search (e.g. Godzilla series, convention promos)
+        search = from_json(
+            _SearchResponse,
+            _request_scryfall(
+                'https://api.scryfall.com/cards/search',
+                params={'q': f'flavor_name:"{name}"', 'unique': 'cards'},
+            ).content,
+        )
+        if not search.data:
+            raise  # flavour name search gave nothing, re-raise original error
+
+        card = search.data[0]
+
+    # If we've filters, then look through all printings for the best variant.
+    needs_filtering = (
+        prefer_langs
+        or prefer_older_sets
+        or prefer_sets
+        or ignore_sets
+        or prefer_showcase
+        or prefer_extra_art
+        or prefer_ub
+        or ignore_ub
+    )
+    if needs_filtering:
+        ub_preference = True if prefer_ub else (False if ignore_ub else None)
+        printings = _fetch_printings(name, card.prints_search_uri, ub_preference)
+        assert printings  # ?? found one card instance, but no printings?
+
+        remaining = [c for c in printings if c.set not in ignore_sets]
+        if remaining:
+            printings = remaining
+        else:
+            print(
+                f'All printings for "{name}" are in ignored sets. Ignoring --ignore_set.'
+            )
+
+        # ASSUME: `card_printings` sorted by age, newest first
+        if prefer_older_sets:
+            printings.reverse()
+
+        filtered = _progressive_filtering(printings, prefer_filters)
+        if filtered:
+            card = filtered[0]
+        else:
+            print(
+                f'No printings found for "{name}" with preferred options. Using default instead.'
+            )
+
+    return card

--- a/plugins/mtg/scryfall.py
+++ b/plugins/mtg/scryfall.py
@@ -1,17 +1,16 @@
 import os
+import time
 from io import BytesIO
 from typing import List, Optional, Tuple
-from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
-import requests
-import time
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
+import requests
 from PIL import Image
 
-from .common import remove_nonalphanumeric, ScryfallLanguage, to_scryfall_api_lang
+from . import remote
+from .common import ScryfallLanguage, remove_nonalphanumeric, to_scryfall_api_lang
 
 double_sided_layouts = ['transform', 'modal_dfc', 'double_faced_token', 'reversible_card', 'meld']
-
-session = requests.Session()
 
 def append_search_filter(uri: str, filter_term: str) -> str:
     parsed = urlparse(uri)
@@ -35,23 +34,12 @@ def fetch_printings(prints_search_uri: str, prefer_ub: Optional[bool], name: str
         print(f'{label} printings for "{name}" are Universe Beyond. Ignoring {flag}.')
     return request_scryfall(prints_search_uri).json()['data']
 
+@remote.memo
 def request_scryfall(
     query: str,
     params: dict = None,
-    retry_count: int = 0,
 ) -> requests.Response:
-    r = session.get(query, params=params, headers = {'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
-
-    # Rate limit check - Scryfall requires 30 second wait per their documentation
-    if r.status_code == 429:
-        if retry_count >= 3:
-            print(f"Warning: Hit rate limit 3 times for {query}, giving up after 30s wait")
-            raise requests.exceptions.HTTPError(f"Max retries (3) exceeded for Scryfall API: {query}", response=r)
-        print(f"Hit Scryfall rate limit (429), waiting 30 seconds before retry {retry_count + 1}/3...")
-        time.sleep(30)
-        return request_scryfall(query, params, retry_count + 1)
-
-    r.raise_for_status()
+    r = remote.get(query, params)
 
     # Apply rate limiting per Scryfall API documentation
     # See: https://scryfall.com/docs/api/rate-limits

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click==8.1.8
 cloudscraper==1.2.71
 ezdxf==1.4.2
 filetype==1.2.0
+joblib==1.5.3
 matplotlib==3.10.5
 mtg_parser==0.0.1a50
 natsort==8.4.0
@@ -9,7 +10,7 @@ numpy==2.4.2
 pillow==12.1.1
 pyautogui==0.9.54
 pydantic==2.12.5
-pywinauto==0.6.9
 pypdfium2==4.30.0
+pywinauto==0.6.9
 requests==2.32.4
 split-image==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ pillow==12.1.1
 pyautogui==0.9.54
 pydantic==2.12.5
 pypdfium2==4.30.0
+pyserde==0.31.7
 pywinauto==0.6.9
 requests==2.32.4
 split-image==2.0.1

--- a/test/test_mtg_plugin.py
+++ b/test/test_mtg_plugin.py
@@ -2,30 +2,81 @@
 Tests for the MTG plugin.
 Tests deck format parsing and image fetching from Scryfall.
 """
-import os
+
+import copy
 import shutil
 import tempfile
+import uuid
+from io import BytesIO
+from collections import OrderedDict
+from datetime import datetime
+from typing import Any, Callable
+from unittest.mock import MagicMock, patch
+
 import pytest
 import requests
-from unittest.mock import patch, MagicMock
+from serde.json import from_json, to_json
 
+from plugins.mtg import scryfall
+from plugins.mtg.common import MtgPrintedLanguage
 from plugins.mtg.deck_formats import (
+    DeckEntry,
     DeckFormat,
-    parse_deck,
-    parse_simple_list,
-    parse_mtga,
-    parse_mtgo,
+    DeckParse,
+    FetchCard,
     parse_archidekt,
+    parse_deck,
     parse_deckstats,
     parse_moxfield,
+    parse_mtga,
+    parse_mtgo,
     parse_scryfall_json,
+    parse_simple_list,
 )
-from plugins.mtg.common import ScryfallLanguage, to_scryfall_api_lang
-from plugins.mtg.scryfall import request_scryfall, get_handle_card, fetch_card, fetch_printings, build_image_url, fetch_image
-from typing import List
-from plugins.mtg.patterns import MOXFIELD_PATTERN, DECKSTATS_PATTERN
+from plugins.mtg.patterns import DECKSTATS_PATTERN, MOXFIELD_PATTERN
+from plugins.mtg.scryfall import (
+    Card,
+    CardName,
+    CollectorNumber,
+    SetCode,
+    _build_image_url,
+    _fetch_printings,
+    _request_scryfall,
+)
 
 # --- Unit Tests for Deck Format Parsing ---
+
+
+def _dummy_fetch_card(
+    name: CardName, set_code: SetCode | None, collector_number: CollectorNumber | None
+) -> Card:
+    return _mk_card(name, set_code or '', collector_number or '')
+
+
+def _verify_deckparse(
+    errs: list[tuple[str, Exception]],
+    deck: OrderedDict[Card, int],
+    expected_cards: list[DeckEntry],
+):
+    assert not errs
+    assert len(expected_cards) == len(deck)
+    for (name, card_set, collector_number, expected_quantity), (card, quantity) in zip(
+        expected_cards, deck.items()
+    ):
+        assert name == card.name
+        assert card_set == card.set
+        assert collector_number == card.collector_number
+        assert expected_quantity == quantity
+
+
+def _verify_deck_parser(
+    deck_parser: Callable[[str, FetchCard], DeckParse],
+    deck_text: str,
+    expected_cards: list[DeckEntry],
+):
+    errs, deck = deck_parser(deck_text, _dummy_fetch_card)
+    _verify_deckparse(errs, deck, expected_cards)
+
 
 class TestDeckFormatParsing:
     """Test regex pattern matching for special deck format cases."""
@@ -42,7 +93,6 @@ class TestDeckFormatParsing:
         assert match.group(3) == "SLD"
         assert match.group(4) == "123★"
 
-
     def test_collector_number_with_dash(self):
         """Test that collector numbers with dashes are matched."""
         # Collector numbers like "123-456" should also be captured
@@ -51,7 +101,6 @@ class TestDeckFormatParsing:
 
         assert match is not None
         assert match.group(4) == "123-456"
-
 
     def test_quantity_with_x(self):
         """Test that quantities with "x" suffix are matched."""
@@ -64,7 +113,6 @@ class TestDeckFormatParsing:
         assert match.group(2) == "Lightning Bolt"
         assert match.group(3) == "2XM"
         assert match.group(4) == "117"
-
 
     def test_deckstats_star_symbol_in_collector_number(self):
         """Test that Deckstats star symbol in collector numbers is matched."""
@@ -79,32 +127,27 @@ class TestDeckFormatParsing:
         assert match.group(3) == "1494★"
         assert match.group(4) == "Sol Ring"
 
+
 class TestSimpleFormat:
     """Test the simple card name list format."""
 
     def test_parse_simple_list(self):
         """Test parsing a simple list of card names."""
-        deck_text = """Isshin, Two Heavens as One
+        deck_text = """
+Isshin, Two Heavens as One
 Arid Mesa
-Battlefield Forge"""
+Battlefield Forge
+"""
 
-        parsed_cards = []
-        def collect_card(index, name, set_code, collector_number, quantity):
-            parsed_cards.append({
-                'index': index,
-                'name': name,
-                'set_code': set_code,
-                'collector_number': collector_number,
-                'quantity': quantity
-            })
-
-        parse_simple_list(deck_text, collect_card)
-
-        assert len(parsed_cards) == 3
-        assert parsed_cards[0]['name'] == "Isshin, Two Heavens as One"
-        assert parsed_cards[0]['quantity'] == 1
-        assert parsed_cards[1]['name'] == "Arid Mesa"
-        assert parsed_cards[2]['name'] == "Battlefield Forge"
+        _verify_deck_parser(
+            parse_simple_list,
+            deck_text,
+            [
+                ("Isshin, Two Heavens as One", '', '', 1),
+                ("Arid Mesa", '', '', 1),
+                ("Battlefield Forge", '', '', 1),
+            ],
+        )
 
 
 class TestMTGAFormat:
@@ -112,27 +155,20 @@ class TestMTGAFormat:
 
     def test_parse_mtga_with_set_info(self):
         """Test parsing MTGA format with set and collector number."""
-        deck_text = """Deck
+        deck_text = """
+Deck
 2 Arid Mesa (MH2) 244
-1 Lion Sash (NEO) 26"""
+1 Lion Sash (NEO) 26
+"""
 
-        parsed_cards = []
-        def collect_card(index, name, set_code, collector_number, quantity):
-            parsed_cards.append({
-                'index': index,
-                'name': name,
-                'set_code': set_code,
-                'collector_number': collector_number,
-                'quantity': quantity
-            })
-
-        parse_mtga(deck_text, collect_card)
-
-        assert len(parsed_cards) == 2
-        assert parsed_cards[0]['name'] == "Arid Mesa"
-        assert parsed_cards[0]['set_code'] == "MH2"
-        assert parsed_cards[0]['collector_number'] == "244"
-        assert parsed_cards[0]['quantity'] == 2
+        _verify_deck_parser(
+            parse_mtga,
+            deck_text,
+            [
+                ("Arid Mesa", "MH2", '244', 2),
+                ("Lion Sash", "NEO", '26', 1),
+            ],
+        )
 
     def test_parse_mtga_without_set_info(self):
         """Test parsing MTGA format without set information."""
@@ -140,21 +176,14 @@ class TestMTGAFormat:
 2x Mountain
 1 Lightning Bolt"""
 
-        parsed_cards = []
-        def collect_card(index, name, set_code, collector_number, quantity):
-            parsed_cards.append({
-                'index': index,
-                'name': name,
-                'set_code': set_code,
-                'collector_number': collector_number,
-                'quantity': quantity
-            })
-
-        parse_mtga(deck_text, collect_card)
-
-        assert len(parsed_cards) == 2
-        assert parsed_cards[0]['name'] == "Mountain"
-        assert parsed_cards[0]['set_code'] == ""
+        _verify_deck_parser(
+            parse_mtga,
+            deck_text,
+            [
+                ("Mountain", '', '', 2),
+                ("Lightning Bolt", '', '', 1),
+            ],
+        )
 
 
 class TestMTGOFormat:
@@ -162,27 +191,23 @@ class TestMTGOFormat:
 
     def test_parse_mtgo(self):
         """Test parsing MTGO format."""
-        deck_text = """1 Ainok Bond-Kin
+        deck_text = """
+1 Ainok Bond-Kin
 2 Witch Enchanter
 
 SIDEBOARD:
-1 Containment Priest"""
+1 Containment Priest
+"""
 
-        parsed_cards = []
-        def collect_card(index, name, set_code, collector_number, quantity):
-            parsed_cards.append({
-                'index': index,
-                'name': name,
-                'quantity': quantity
-            })
-
-        parse_mtgo(deck_text, collect_card)
-
-        assert len(parsed_cards) == 3
-        assert parsed_cards[0]['name'] == "Ainok Bond-Kin"
-        assert parsed_cards[0]['quantity'] == 1
-        assert parsed_cards[1]['name'] == "Witch Enchanter"
-        assert parsed_cards[1]['quantity'] == 2
+        _verify_deck_parser(
+            parse_mtgo,
+            deck_text,
+            [
+                ("Ainok Bond-Kin", '', '', 1),
+                ("Witch Enchanter", '', '', 2),
+                ("Containment Priest", '', '', 1),
+            ],
+        )
 
 
 class TestArchidektFormat:
@@ -190,25 +215,19 @@ class TestArchidektFormat:
 
     def test_parse_archidekt(self):
         """Test parsing Archidekt format with tags and foil markers."""
-        deck_text = """1x Agadeem's Awakening // Agadeem, the Undercrypt (znr) 90 [Resilience,Land]
-1x Ashnod's Altar (ema) 218 *F* [Mana Advantage]"""
+        deck_text = """
+10x Agadeem's Awakening // Agadeem, the Undercrypt (znr) 90 [Resilience,Land]
+2x Ashnod's Altar (ema) 218 *F* [Mana Advantage]
+"""
 
-        parsed_cards = []
-        def collect_card(index, name, set_code, collector_number, quantity):
-            parsed_cards.append({
-                'index': index,
-                'name': name,
-                'set_code': set_code,
-                'collector_number': collector_number,
-                'quantity': quantity
-            })
-
-        parse_archidekt(deck_text, collect_card)
-
-        assert len(parsed_cards) == 2
-        assert parsed_cards[0]['name'] == "Agadeem's Awakening // Agadeem, the Undercrypt"
-        assert parsed_cards[0]['set_code'] == "znr"
-        assert parsed_cards[0]['collector_number'] == "90"
+        _verify_deck_parser(
+            parse_archidekt,
+            deck_text,
+            [
+                ("Agadeem's Awakening // Agadeem, the Undercrypt", 'znr', '90', 10),
+                ("Ashnod's Altar", "ema", '218', 2),
+            ],
+        )
 
 
 class TestDeckstatsFormat:
@@ -217,41 +236,33 @@ class TestDeckstatsFormat:
     def test_parse_deckstats_with_set(self):
         """Test parsing Deckstats format with set info."""
         deck_text = """//Main
-1 [2XM#310] Ash Barrens
-1 Blinkmoth Nexus"""
+131 [2XM#310] Ash Barrens
+17 Blinkmoth Nexus
+"""
 
-        parsed_cards = []
-        def collect_card(index, name, set_code, collector_number, quantity):
-            parsed_cards.append({
-                'index': index,
-                'name': name,
-                'set_code': set_code,
-                'collector_number': collector_number,
-                'quantity': quantity
-            })
-
-        parse_deckstats(deck_text, collect_card)
-
-        assert len(parsed_cards) == 2
-        assert parsed_cards[0]['name'] == "Ash Barrens"
-        assert parsed_cards[0]['set_code'] == "2XM"
-        assert parsed_cards[0]['collector_number'] == "310"
-        assert parsed_cards[1]['name'] == "Blinkmoth Nexus"
-        assert parsed_cards[1]['set_code'] == ""
+        _verify_deck_parser(
+            parse_deckstats,
+            deck_text,
+            [
+                ("Ash Barrens", "2XM", '310', 131),
+                ("Blinkmoth Nexus", '', '', 17),
+            ],
+        )
 
     def test_strips_commander_annotation(self):
         """Test that #!Commander annotation is stripped from card names."""
-        deck_text = "1 Varragoth, Bloodsky Sire #!Commander"
+        deck_text = """
+1 Varragoth, Bloodsky Sire #!Commander
+1 Varragoth, Bloodsky Sire #!Commander
+"""
 
-        parsed_cards = []
-        def collect_card(index, name, set_code, collector_number, quantity):
-            parsed_cards.append({'index': index, 'name': name, 'set_code': set_code, 'collector_number': collector_number, 'quantity': quantity})
-
-        parse_deckstats(deck_text, collect_card)
-
-        assert len(parsed_cards) == 1
-        assert parsed_cards[0]['name'] == "Varragoth, Bloodsky Sire"
-        assert parsed_cards[0]['quantity'] == 1
+        _verify_deck_parser(
+            parse_deckstats,
+            deck_text,
+            [
+                ("Varragoth, Bloodsky Sire", '', '', 2),
+            ],
+        )
 
 
 class TestMoxfieldFormat:
@@ -259,391 +270,280 @@ class TestMoxfieldFormat:
 
     def test_parse_moxfield(self):
         """Test parsing Moxfield format."""
-        deck_text = """1 Ainok Bond-Kin (2X2) 5
-2 Witch Enchanter // Witch-Blessed Meadow (MH3) 239"""
+        deck_text = """
+1 Ainok Bond-Kin (2X2) 5
+2 Witch Enchanter // Witch-Blessed Meadow (MH3) 239
+"""
 
-        parsed_cards = []
-        def collect_card(index, name, set_code, collector_number, quantity):
-            parsed_cards.append({
-                'index': index,
-                'name': name,
-                'set_code': set_code,
-                'collector_number': collector_number,
-                'quantity': quantity
-            })
-
-        parse_moxfield(deck_text, collect_card)
-
-        assert len(parsed_cards) == 2
-        assert parsed_cards[0]['name'] == "Ainok Bond-Kin"
-        assert parsed_cards[0]['set_code'] == "2X2"
-        assert parsed_cards[1]['name'] == "Witch Enchanter // Witch-Blessed Meadow"
+        _verify_deck_parser(
+            parse_moxfield,
+            deck_text,
+            [
+                ("Ainok Bond-Kin", "2X2", '5', 1),
+                ("Witch Enchanter // Witch-Blessed Meadow", 'MH3', '239', 2),
+            ],
+        )
 
 
 class TestScryfallJsonFormat:
     """Test Scryfall JSON format parsing."""
 
-    def test_parse_scryfall_json_without_image_uris(self):
-        """Without image_uris, cards are dispatched through handle_card."""
-        deck_text = """{
-  "entries": {
-    "mainboard": [
-      {
-        "count": 2,
-        "card_digest": {
-          "name": "Lightning Bolt",
-          "collector_number": "141",
-          "set": "clu"
-        }
-      }
-    ]
-  }
-}"""
-
-        parsed_cards = []
-        def collect_card(index, name, set_code, collector_number, quantity):
-            parsed_cards.append({
-                'index': index,
-                'name': name,
-                'set_code': set_code,
-                'collector_number': collector_number,
-                'quantity': quantity
-            })
-
-        parse_scryfall_json(deck_text, collect_card)
-
-        assert len(parsed_cards) == 1
-        assert parsed_cards[0]['name'] == "Lightning Bolt"
-        assert parsed_cards[0]['set_code'] == "clu"
-        assert parsed_cards[0]['quantity'] == 2
-
-    @patch('plugins.mtg.deck_formats.requests.get')
-    def test_parse_scryfall_json_with_image_uris_fetches_directly(self, mock_get, tmp_path):
-        """When image_uris.front is present, the image is fetched directly and handle_card is not called."""
-        mock_response = MagicMock()
-        mock_response.content = b'fake_image_data'
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
-
-        deck_text = """{
-  "entries": {
-    "mainboard": [
-      {
-        "count": 2,
-        "card_digest": {
-          "name": "Formidable Speaker",
-          "collector_number": "176",
-          "set": "ecl",
-          "image_uris": {
-            "front": "https://cards.scryfall.io/large/front/9/3/93ac8c22.jpg"
-          }
-        }
-      }
-    ]
-  }
-}"""
-
-        handle_card = MagicMock()
-        front_dir = str(tmp_path / "front")
-        os.makedirs(front_dir)
-
-        parse_scryfall_json(deck_text, handle_card, front_dir, '')
-
-        handle_card.assert_not_called()
-        mock_get.assert_called_once_with(
-            "https://cards.scryfall.io/large/front/9/3/93ac8c22.jpg",
-            headers={'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'}
-        )
-        saved_files = os.listdir(front_dir)
-        assert len(saved_files) == 2  # quantity=2
-
-    @patch('plugins.mtg.deck_formats.requests.get')
-    def test_parse_scryfall_json_with_image_uris_back(self, mock_get, tmp_path):
+    def test_parse_scryfall_json(self):
         """When image_uris.back is present, both front and back images are fetched."""
-        mock_response = MagicMock()
-        mock_response.content = b'fake_image_data'
-        mock_response.raise_for_status.return_value = None
-        mock_get.return_value = mock_response
+        card = _mk_card("Delver of Secrets", "isd", "51")
 
-        deck_text = """{
-  "entries": {
-    "mainboard": [
-      {
-        "count": 1,
-        "card_digest": {
-          "name": "Delver of Secrets",
-          "collector_number": "51",
-          "set": "isd",
-          "image_uris": {
-            "front": "https://cards.scryfall.io/large/front/a/b/front.jpg",
-            "back": "https://cards.scryfall.io/large/back/a/b/back.jpg"
-          }
-        }
-      }
-    ]
-  }
-}"""
+        def fetcher(
+            name: CardName,
+            card_set: SetCode | None,
+            collector_number: CollectorNumber | None,
+        ):
+            assert name == card.name
+            assert card_set == card.set
+            assert collector_number == card.collector_number
+            return card
 
-        front_dir = str(tmp_path / "front")
-        back_dir = str(tmp_path / "back")
-        os.makedirs(front_dir)
-        os.makedirs(back_dir)
+        deck_text = to_json(
+            {"entries": {"mainboard": [{"count": 1, "card_digest": card}]}}
+        )
 
-        parse_scryfall_json(deck_text, MagicMock(), front_dir, back_dir)
-
-        fetched_urls = [call[0][0] for call in mock_get.call_args_list]
-        assert any("front.jpg" in url for url in fetched_urls)
-        assert any("back.jpg" in url for url in fetched_urls)
-        assert len(os.listdir(front_dir)) == 1
-        assert len(os.listdir(back_dir)) == 1
-
+        errors, deck = parse_scryfall_json(deck_text, fetcher)
+        assert errors == []
+        assert len(deck) == 1
+        deck_card, quantity = list(deck.items())[0]
+        assert quantity == 1
+        assert deck_card == card
 
 
 # --- Unit Tests for Scryfall Fetching ---
 
-SHADOWSPEAR_JSON = {
-    'name': 'Shadowspear',
-    'set': 'pza',
-    'collector_number': '17',
-    'layout': 'normal',
-}
+_PRINTS_SEARCH_URI = (
+    'https://api.scryfall.com/cards/search?q=oracleid%3Atest&unique=prints'
+)
 
-PRINTS_SEARCH_URI = 'https://api.scryfall.com/cards/search?q=oracleid%3Atest&unique=prints'
+
+def _mk_card(
+    name: CardName, set: SetCode, collector_number: CollectorNumber, **kw: Any
+) -> Card:
+    def mk_uuid(x: Any):
+        return uuid.UUID(bytes=abs(hash(x)).to_bytes(length=16))
+
+    kw.setdefault('booster', False)
+    kw.setdefault('digital', False)
+    kw.setdefault('full_art', False)
+    kw.setdefault('border_color', scryfall.BorderColour.BLACK)
+    kw.setdefault('id', mk_uuid(name))
+    kw.setdefault('image_status', scryfall.ImageStatus.LOWRES)
+    kw.setdefault('lang', scryfall.Language.ENGLISH)
+    kw.setdefault('layout', scryfall.Layout.NORMAL)
+    kw.setdefault('nonfoil', True)
+    kw.setdefault('oversized', False)
+    kw.setdefault('prints_search_uri', _PRINTS_SEARCH_URI)
+    kw.setdefault('promo', False)
+    kw.setdefault('rarity', scryfall.Rarity.COMMON)
+    kw.setdefault('released_at', datetime.fromtimestamp(0))
+    kw.setdefault('reprint', False)
+    kw.setdefault('rulings_uri', "rulings-uri")
+    kw.setdefault('scryfall_set_uri', "scryfall-set-uri")
+    kw.setdefault('scryfall_uri', "dummy-URI")
+    kw.setdefault('set_id', mk_uuid(set))
+    kw.setdefault('set_name', "set-name-stub")
+    kw.setdefault('set_type', "set-type-stub")
+    kw.setdefault('set_uri', "set-uri")
+    kw.setdefault('story_spotlight', False)
+    kw.setdefault('textless', False)
+    kw.setdefault('uri', "card-uri")
+    kw.setdefault('variation', False)
+    return Card(
+        name=name,
+        set=set,
+        collector_number=collector_number,
+        **kw,
+    )
+
+
+SHADOWSPEAR = _mk_card('Shadowspear', 'pza', '17')
 
 # Skrelv has both a Universe Beyond printing (SLD) and a standard printing (ONE).
-SKRELV_JSON = {
-    'name': 'Skrelv, Defector Mite',
-    'set': 'one',
-    'collector_number': '225',
-    'layout': 'normal',
-    'prints_search_uri': PRINTS_SEARCH_URI,
-}
-SKRELV_UB_PRINTING = {
-    'set': 'sld', 'collector_number': '1926',
-    'nonfoil': True, 'digital': False, 'promo': False,
-    'full_art': False, 'border_color': 'black', 'frame_effects': [],
-}
-SKRELV_NON_UB_PRINTING = {
-    'set': 'one', 'collector_number': '225',
-    'nonfoil': True, 'digital': False, 'promo': False,
-    'full_art': False, 'border_color': 'black', 'frame_effects': [],
-}
+SKRELV_NON_UB_PRINTING = _mk_card('Skrelv, Defector Mite', 'one', '255')
+SKRELV_UB_PRINTING = _mk_card('Skrelv, Defector Mite', 'sld', '1926')
 
 # Excalibur only exists as a Universe Beyond card.
-EXCALIBUR_JSON = {
-    'name': 'Excalibur, Sword of Eden',
-    'set': 'acr',
-    'collector_number': '72',
-    'layout': 'normal',
-    'prints_search_uri': PRINTS_SEARCH_URI,
-}
-EXCALIBUR_PRINTING = {
-    'set': 'acr', 'collector_number': '72',
-    'nonfoil': True, 'digital': False, 'promo': False,
-    'full_art': False, 'border_color': 'black', 'frame_effects': [],
-}
+EXCALIBUR = _mk_card('Excalibur, Sword of Eden', 'acr', '72')
 
-def make_404():
+
+def _make_404():
     err = requests.exceptions.HTTPError()
     err.response = MagicMock()
     err.response.status_code = 404
     return err
 
+
+def _named_response(card: Card):
+    r = MagicMock()
+    r.content = to_json(card)
+    return r
+
+
+def _printings_response(printings: list[Card]):
+    r = MagicMock()
+    r.content = to_json({'data': printings})
+    return r
+
+
 class TestFetchPrintingsUB:
     """Unit tests for Universe Beyond filtering in fetch_printings."""
 
-    @patch('plugins.mtg.scryfall.request_scryfall')
+    @patch('plugins.mtg.scryfall._request_scryfall')
     def test_prefer_ub_returns_ub_printings_when_available(self, mock_request):
         """prefer_ub=True fetches with is:ub filter and returns those results."""
-        ub_response = MagicMock()
-        ub_response.json.return_value = {'data': [SKRELV_UB_PRINTING]}
-        mock_request.return_value = ub_response
+        mock_request.return_value = _printings_response([SKRELV_UB_PRINTING])
 
-        result = fetch_printings(PRINTS_SEARCH_URI, True, 'Skrelv, Defector Mite')
+        result = _fetch_printings('Skrelv, Defector Mite', _PRINTS_SEARCH_URI, True)
 
         assert result == [SKRELV_UB_PRINTING]
         called_url = mock_request.call_args_list[0][0][0]
         assert 'is%3Aub' in called_url or 'is:ub' in called_url
 
-    @patch('plugins.mtg.scryfall.request_scryfall')
+    @patch('plugins.mtg.scryfall._request_scryfall')
     def test_ignore_ub_returns_non_ub_printings_when_available(self, mock_request):
         """ignore_ub=True fetches with -is:ub filter and returns those results."""
-        non_ub_response = MagicMock()
-        non_ub_response.json.return_value = {'data': [SKRELV_NON_UB_PRINTING]}
-        mock_request.return_value = non_ub_response
+        mock_request.return_value = _printings_response([SKRELV_NON_UB_PRINTING])
 
-        result = fetch_printings(PRINTS_SEARCH_URI, False, 'Skrelv, Defector Mite')
+        result = _fetch_printings('Skrelv, Defector Mite', _PRINTS_SEARCH_URI, False)
 
         assert result == [SKRELV_NON_UB_PRINTING]
         called_url = mock_request.call_args_list[0][0][0]
         assert '-is%3Aub' in called_url or '-is:ub' in called_url
 
-    @patch('plugins.mtg.scryfall.request_scryfall')
+    @patch('plugins.mtg.scryfall._request_scryfall')
     def test_prefer_ub_falls_back_when_no_ub_printings(self, mock_request):
         """prefer_ub=True falls back to all printings when no UB printings exist."""
-        ub_response = MagicMock()
-        ub_response.json.return_value = {'data': []}
-        fallback_response = MagicMock()
-        fallback_response.json.return_value = {'data': [EXCALIBUR_PRINTING]}
-        mock_request.side_effect = [ub_response, fallback_response]
+        mock_request.side_effect = [
+            _printings_response([]),
+            _printings_response([EXCALIBUR]),
+        ]
 
-        result = fetch_printings(PRINTS_SEARCH_URI, True, 'Excalibur, Sword of Eden')
+        result = _fetch_printings('Excalibur, Sword of Eden', _PRINTS_SEARCH_URI, True)
 
-        assert result == [EXCALIBUR_PRINTING]
+        assert result == [EXCALIBUR]
         assert mock_request.call_count == 2
 
-    @patch('plugins.mtg.scryfall.request_scryfall')
+    @patch('plugins.mtg.scryfall._request_scryfall')
     def test_ignore_ub_falls_back_when_all_printings_are_ub(self, mock_request):
         """ignore_ub=True falls back to all printings when no non-UB printings exist."""
-        non_ub_response = MagicMock()
-        non_ub_response.json.return_value = {'data': []}
-        fallback_response = MagicMock()
-        fallback_response.json.return_value = {'data': [EXCALIBUR_PRINTING]}
-        mock_request.side_effect = [non_ub_response, fallback_response]
+        mock_request.side_effect = [
+            _printings_response([]),
+            _printings_response([EXCALIBUR]),
+        ]
 
-        result = fetch_printings(PRINTS_SEARCH_URI, False, 'Excalibur, Sword of Eden')
+        result = _fetch_printings('Excalibur, Sword of Eden', _PRINTS_SEARCH_URI, False)
 
-        assert result == [EXCALIBUR_PRINTING]
+        assert result == [EXCALIBUR]
         assert mock_request.call_count == 2
 
-    @patch('plugins.mtg.scryfall.request_scryfall')
+    @patch('plugins.mtg.scryfall._request_scryfall')
     def test_no_ub_filter_fetches_all_printings(self, mock_request):
         """prefer_ub=None skips the filtered request entirely."""
-        all_response = MagicMock()
-        all_response.json.return_value = {'data': [SKRELV_UB_PRINTING, SKRELV_NON_UB_PRINTING]}
-        mock_request.return_value = all_response
+        mock_request.return_value = _printings_response(
+            [SKRELV_UB_PRINTING, SKRELV_NON_UB_PRINTING]
+        )
 
-        result = fetch_printings(PRINTS_SEARCH_URI, None, 'Skrelv, Defector Mite')
+        result = _fetch_printings('Skrelv, Defector Mite', _PRINTS_SEARCH_URI, None)
 
         assert result == [SKRELV_UB_PRINTING, SKRELV_NON_UB_PRINTING]
         assert mock_request.call_count == 1
-        assert mock_request.call_args_list[0][0][0] == PRINTS_SEARCH_URI
+        assert mock_request.call_args_list[0][0][0] == _PRINTS_SEARCH_URI
 
 
 class TestFetchCardUB:
     """Unit tests for prefer_ub/ignore_ub integration inside fetch_card."""
 
-    def named_response(self, card_json):
-        r = MagicMock()
-        r.json.return_value = card_json
-        return r
-
-    def printings_response(self, printings):
-        r = MagicMock()
-        r.json.return_value = {'data': printings}
-        return r
-
-    @patch('plugins.mtg.scryfall.fetch_card_art')
-    @patch('plugins.mtg.scryfall.request_scryfall')
-    def test_prefer_ub_selects_ub_printing(self, mock_request, mock_fetch_art):
+    @patch('plugins.mtg.scryfall._request_scryfall')
+    def test_prefer_ub_selects_ub_printing(self, mock_request):
         """With prefer_ub=True, the UB printing is selected over the standard one."""
         mock_request.side_effect = [
-            self.named_response(SKRELV_JSON),           # /cards/named
-            self.printings_response([SKRELV_UB_PRINTING]),  # is:ub filtered search
+            _named_response(SKRELV_NON_UB_PRINTING),  # /cards/named
+            _printings_response([SKRELV_UB_PRINTING]),  # is:ub filtered search
         ]
 
-        fetch_card(1, 1, "", "", False, "Skrelv, Defector Mite",
-                   False, set(), set(), False, False, True, False, None, False,
-                   front_img_dir='front', double_sided_dir='double_sided')
+        card = scryfall.fetch_card(
+            name="Skrelv, Defector Mite",
+            prefer_ub=True,
+        )
 
-        args, _ = mock_fetch_art.call_args
-        assert args[3] == 'sld'
-        assert args[4] == '1926'
+        assert card.set == 'sld'
+        assert card.collector_number == '1926'
 
-    @patch('plugins.mtg.scryfall.fetch_card_art')
-    @patch('plugins.mtg.scryfall.request_scryfall')
-    def test_ignore_ub_selects_non_ub_printing(self, mock_request, mock_fetch_art):
+    @patch('plugins.mtg.scryfall._request_scryfall')
+    def test_ignore_ub_selects_non_ub_printing(self, mock_request):
         """With ignore_ub=True, the non-UB printing is selected."""
         mock_request.side_effect = [
-            self.named_response(SKRELV_JSON),                    # /cards/named
-            self.printings_response([SKRELV_NON_UB_PRINTING]),   # -is:ub filtered search
+            _named_response(SKRELV_UB_PRINTING),  # /cards/named
+            _printings_response([SKRELV_NON_UB_PRINTING]),  # -is:ub filtered search
         ]
 
-        fetch_card(1, 1, "", "", False, "Skrelv, Defector Mite",
-                   False, set(), set(), False, False, False, True, None, False,
-                   front_img_dir='front', double_sided_dir='double_sided')
+        card = scryfall.fetch_card(
+            name="Skrelv, Defector Mite",
+            ignore_ub=True,
+        )
 
-        args, _ = mock_fetch_art.call_args
-        assert args[3] == 'one'
-        assert args[4] == '225'
+        assert card.set == 'one'
+        assert card.collector_number == '255'
 
-    @patch('plugins.mtg.scryfall.fetch_card_art')
-    @patch('plugins.mtg.scryfall.request_scryfall')
-    def test_prefer_ub_falls_back_for_ub_only_card(self, mock_request, mock_fetch_art):
+    @patch('plugins.mtg.scryfall._request_scryfall')
+    def test_prefer_ub_falls_back_for_ub_only_card(self, mock_request):
         """With prefer_ub=True on a UB-only card, the UB printing is used after fallback."""
         mock_request.side_effect = [
-            self.named_response(EXCALIBUR_JSON),            # /cards/named
-            self.printings_response([]),                     # is:ub → empty (no non-UB)
-            self.printings_response([EXCALIBUR_PRINTING]),  # fallback to all printings
+            _named_response(EXCALIBUR),  # /cards/named
+            _printings_response([]),  # is:ub → empty (no non-UB)
+            _printings_response([EXCALIBUR]),  # fallback to all printings
         ]
 
-        fetch_card(1, 1, "", "", False, "Excalibur, Sword of Eden",
-                   False, set(), set(), False, False, True, False, None, False,
-                   front_img_dir='front', double_sided_dir='double_sided')
+        card = scryfall.fetch_card(
+            name="Excalibur, Sword of Eden",
+            ignore_ub=True,
+        )
 
-        args, _ = mock_fetch_art.call_args
-        assert args[3] == 'acr'
-        assert args[4] == '72'
+        assert card.set == 'acr'
+        assert card.collector_number == '72'
 
 
 class TestScryfallFetch:
     """Unit tests for Scryfall card fetching logic."""
 
-    @patch('plugins.mtg.scryfall.fetch_card_art')
-    @patch('plugins.mtg.scryfall.request_scryfall')
-    def test_flavor_name_card_is_fetched(self, mock_request, mock_fetch_art):
+    @patch('plugins.mtg.scryfall._request_scryfall')
+    def test_flavor_name_card_is_fetched(self, mock_request):
         """A card known only by its flavor name still has its art fetched successfully."""
-        search_response = MagicMock()
-        search_response.json.return_value = {'data': [SHADOWSPEAR_JSON]}
-        mock_request.side_effect = [make_404(), search_response]
+        mock_request.side_effect = [
+            _make_404(),
+            _printings_response([SHADOWSPEAR]),
+        ]
 
-        fetch_card(1, 1, "", "", False, "Donnie's Bō",
-                   False, set(), set(), False, False, False, False, None, False,
-                   front_img_dir='front', double_sided_dir='double_sided')
-
-        mock_fetch_art.assert_called_once()
+        _ = scryfall.fetch_card(name="Donnie's Bō")
 
     @patch('plugins.mtg.scryfall.remote._session.get')
     def test_image_fetched_with_lowercase_set_code(self, mock_get):
         """When given an uppercase set code, the image is fetched using the lowercase code returned by the API."""
-        info_response = MagicMock(status_code=200)
-        info_response.raise_for_status.return_value = None
-        info_response.json.return_value = {
-            'name': 'Felidar Retreat',
-            'set': 'fdn',
-            'collector_number': '574',
-            'layout': 'normal',
-        }
-        image_response = MagicMock(status_code=200)
-        image_response.raise_for_status.return_value = None
-        image_response.content = b'fake_image'
-
-        mock_get.side_effect = [info_response, image_response]
+        mock_get.side_effect = [
+            _named_response(_mk_card('Felidar Retreat', 'fdn', '574'))
+        ]
 
         with patch('builtins.open', MagicMock()):
-            fetch_card(1, 1, "FDN", "574", False, "Felidar Retreat",
-                       False, set(), set(), False, False, False, False, None, False,
-                       front_img_dir='front', double_sided_dir='double_sided')
+            card = scryfall.fetch_card(
+                name="Felidar Retreat",
+                set_code="FDN",
+                collector_number="574",
+            )
 
-        # call_args_list is a list of all calls made to mock_get, in order.
-        # [1]    → the second call (index 1), which is the image fetch (after the card info fetch)
-        # [0]    → the positional args tuple for that call
-        # [0]    → the first positional argument, which is the URL string
-        image_url = mock_get.call_args_list[1][0][0]
-        assert '/fdn/' in image_url
-        assert '/FDN/' not in image_url
+        assert card.set == 'fdn'
+        assert card.collector_number == '574'
 
-    @patch('plugins.mtg.scryfall.fetch_card_art')
-    @patch('plugins.mtg.scryfall.request_scryfall')
-    def test_found_by_exact_name_does_not_call_flavor_search(self, mock_request, mock_fetch_art):
+    @patch('plugins.mtg.scryfall._request_scryfall')
+    def test_found_by_exact_name_does_not_call_flavor_search(self, mock_request):
         """When a card is found by its exact name, no additional flavor name search is made."""
-        named_response = MagicMock()
-        named_response.json.return_value = SHADOWSPEAR_JSON
-        mock_request.return_value = named_response
+        mock_request.return_value = _named_response(SHADOWSPEAR)
 
-        fetch_card(1, 1, "", "", False, "Shadowspear",
-                   False, set(), set(), False, False, False, False, None, False,
-                   front_img_dir='front', double_sided_dir='double_sided')
+        _card = scryfall.fetch_card(name="Shadowspear")
 
         # Build a list of every URL string passed to request_scryfall across all calls.
         # call_args_list → list of calls, one per request_scryfall invocation
@@ -651,89 +551,88 @@ class TestScryfallFetch:
         # call[0][0]     → first positional argument, which is the URL string
         called_urls = [call[0][0] for call in mock_request.call_args_list]
         assert not any('flavor_name' in url for url in called_urls)
-        mock_fetch_art.assert_called_once()
 
 
 # --- Unit Tests for Language Support ---
 
+
 class TestScryfallLanguageEnum:
-    """Test ScryfallLanguage enum values and mapping to Scryfall API codes."""
+    """Test MtgPrintedLanguage enum values and mapping to Scryfall API codes."""
 
     def test_all_printed_codes_present(self):
         """All supported printed codes are present in the enum."""
-        expected_printed_codes = {"en", "sp", "fr", "de", "it", "pt", "jp", "kr", "ru", "cs", "ct", "ag", "ph"}
-        actual_codes = {lang.value for lang in ScryfallLanguage}
-        assert actual_codes == expected_printed_codes
+        expected_printed_codes = {
+            "en",
+            "sp",
+            "fr",
+            "de",
+            "it",
+            "pt",
+            "jp",
+            "kr",
+            "ru",
+            "cs",
+            "ct",
+            "ag",
+            "ph",
+        }
+        assert len(MtgPrintedLanguage) == len(expected_printed_codes)
+        for lang in expected_printed_codes:
+            # test it both constructs and is an identity map
+            assert MtgPrintedLanguage(lang).value == lang
 
-    def test_enum_values_are_printed_codes(self):
-        """Enum values match the Scryfall printed code column."""
-        assert ScryfallLanguage.ENGLISH.value == "en"
-        assert ScryfallLanguage.SPANISH.value == "sp"
-        assert ScryfallLanguage.FRENCH.value == "fr"
-        assert ScryfallLanguage.GERMAN.value == "de"
-        assert ScryfallLanguage.ITALIAN.value == "it"
-        assert ScryfallLanguage.PORTUGUESE.value == "pt"
-        assert ScryfallLanguage.JAPANESE.value == "jp"
-        assert ScryfallLanguage.KOREAN.value == "kr"
-        assert ScryfallLanguage.RUSSIAN.value == "ru"
-        assert ScryfallLanguage.SIMPLIFIED_CHINESE.value == "cs"
-        assert ScryfallLanguage.TRADITIONAL_CHINESE.value == "ct"
-        assert ScryfallLanguage.ANCIENT_GREEK.value == "ag"
-        assert ScryfallLanguage.PHYREXIAN.value == "ph"
+    def test_print_injective_to_scryfall(self):
+        """Printed language codes are injective to Scryfall language codes."""
+        mapping = {
+            scryfall.Language.from_printed_lang(code) for code in MtgPrintedLanguage
+        }
+        assert len(mapping) == len(MtgPrintedLanguage)
 
     def test_to_scryfall_api_lang_non_trivial_mappings(self):
         """Printed codes that differ from the Scryfall API code are mapped correctly."""
-        assert to_scryfall_api_lang(ScryfallLanguage.SPANISH)           == "es"
-        assert to_scryfall_api_lang(ScryfallLanguage.JAPANESE)          == "ja"
-        assert to_scryfall_api_lang(ScryfallLanguage.KOREAN)            == "ko"
-        assert to_scryfall_api_lang(ScryfallLanguage.SIMPLIFIED_CHINESE)  == "zhs"
-        assert to_scryfall_api_lang(ScryfallLanguage.TRADITIONAL_CHINESE) == "zht"
-        assert to_scryfall_api_lang(ScryfallLanguage.ANCIENT_GREEK)     == "grc"
-
-    def test_to_scryfall_api_lang_identity_mappings(self):
-        """Printed codes that are the same as the Scryfall API code pass through unchanged."""
-        for lang in (ScryfallLanguage.ENGLISH, ScryfallLanguage.FRENCH, ScryfallLanguage.GERMAN,
-                     ScryfallLanguage.ITALIAN, ScryfallLanguage.PORTUGUESE, ScryfallLanguage.RUSSIAN,
-                     ScryfallLanguage.PHYREXIAN):
-            assert to_scryfall_api_lang(lang) == lang.value
-
-    def test_construct_via_printed_code(self):
-        """ScryfallLanguage can be constructed from a printed code string."""
-        assert ScryfallLanguage("jp") == ScryfallLanguage.JAPANESE
-        assert ScryfallLanguage("cs") == ScryfallLanguage.SIMPLIFIED_CHINESE
+        expected_non_trivials = {
+            MtgPrintedLanguage.ANCIENT_GREEK,
+            MtgPrintedLanguage.JAPANESE,
+            MtgPrintedLanguage.KOREAN,
+            MtgPrintedLanguage.SIMPLIFIED_CHINESE,
+            MtgPrintedLanguage.SPANISH,
+            MtgPrintedLanguage.TRADITIONAL_CHINESE,
+        }
+        non_trivials = {
+            code
+            for code in MtgPrintedLanguage
+            if scryfall.Language.from_printed_lang(code).value != code.value
+        }
+        assert non_trivials == expected_non_trivials
 
 
 class TestBuildImageUrl:
     """Test URL construction for different language preferences."""
 
     def test_english_produces_default_url(self):
-        url = build_image_url("lea", "1", ScryfallLanguage.ENGLISH)
+        url = _build_image_url("lea", "1", scryfall.Language.ENGLISH)
         assert url == "https://api.scryfall.com/cards/lea/1/?format=image&version=png"
         assert "/en?" not in url
 
-    def test_none_produces_default_url(self):
-        url = build_image_url("lea", "1", None)
-        assert url == "https://api.scryfall.com/cards/lea/1/?format=image&version=png"
-
     def test_non_english_embeds_api_lang_code(self):
-        url = build_image_url("lea", "1", ScryfallLanguage.JAPANESE)
+        url = _build_image_url("lea", "1", scryfall.Language.JAPANESE)
         assert url == "https://api.scryfall.com/cards/lea/1/ja?format=image&version=png"
 
     def test_spanish_uses_api_code_not_printed_code(self):
         """Printed code 'sp' must map to API code 'es' in the URL."""
-        url = build_image_url("lea", "1", ScryfallLanguage.SPANISH)
+        url = _build_image_url("lea", "1", scryfall.Language.SPANISH)
         assert "/es?" in url
         assert "/sp?" not in url
 
     def test_simplified_chinese_uses_zhs(self):
-        url = build_image_url("lea", "1", ScryfallLanguage.SIMPLIFIED_CHINESE)
+        url = _build_image_url("lea", "1", scryfall.Language.SIMPLIFIED_CHINESE)
         assert "/zhs?" in url
 
 
 class TestFetchImageLanguageFallback:
     """Test that fetch_image tries langs in priority order, falling back to English."""
 
-    @patch('plugins.mtg.scryfall.request_scryfall')
+    @patch('plugins.mtg.scryfall._request_scryfall')
     def test_falls_back_to_english_on_404(self, mock_request):
         lang_404 = requests.exceptions.HTTPError()
         lang_404.response = MagicMock()
@@ -743,7 +642,7 @@ class TestFetchImageLanguageFallback:
         english_response.content = b'fake_english_image'
         mock_request.side_effect = [lang_404, english_response]
 
-        result = fetch_image("neo", "26", [ScryfallLanguage.JAPANESE])
+        result = scryfall.fetch_image("neo", "26", [scryfall.Language.JAPANESE])
 
         assert result == b'fake_english_image'
         assert mock_request.call_count == 2
@@ -751,7 +650,7 @@ class TestFetchImageLanguageFallback:
         assert "/ja?" not in fallback_url
         assert "neo/26/" in fallback_url
 
-    @patch('plugins.mtg.scryfall.request_scryfall')
+    @patch('plugins.mtg.scryfall._request_scryfall')
     def test_tries_priority_order_before_english(self, mock_request):
         """With [jp, de], tries jp → de → en, returning first success."""
         err_404 = requests.exceptions.HTTPError()
@@ -762,14 +661,16 @@ class TestFetchImageLanguageFallback:
         de_response.content = b'fake_german_image'
         mock_request.side_effect = [err_404, de_response]
 
-        result = fetch_image("lea", "1", [ScryfallLanguage.JAPANESE, ScryfallLanguage.GERMAN])
+        result = scryfall.fetch_image(
+            "lea", "1", [scryfall.Language.JAPANESE, scryfall.Language.GERMAN]
+        )
 
         assert result == b'fake_german_image'
         assert mock_request.call_count == 2
         second_url = mock_request.call_args_list[1][0][0]
         assert "/de?" in second_url
 
-    @patch('plugins.mtg.scryfall.request_scryfall')
+    @patch('plugins.mtg.scryfall._request_scryfall')
     def test_raises_when_all_langs_404(self, mock_request):
         """Raises the last HTTPError when every language including English 404s."""
         err_404 = requests.exceptions.HTTPError()
@@ -778,11 +679,11 @@ class TestFetchImageLanguageFallback:
         mock_request.side_effect = err_404
 
         with pytest.raises(requests.exceptions.HTTPError):
-            fetch_image("lea", "1", [ScryfallLanguage.JAPANESE])
+            scryfall.fetch_image("lea", "1", [scryfall.Language.JAPANESE])
 
         assert mock_request.call_count == 2  # jp + en fallback
 
-    @patch('plugins.mtg.scryfall.request_scryfall')
+    @patch('plugins.mtg.scryfall._request_scryfall')
     def test_does_not_fall_back_on_non_404_error(self, mock_request):
         err_500 = requests.exceptions.HTTPError()
         err_500.response = MagicMock()
@@ -790,11 +691,11 @@ class TestFetchImageLanguageFallback:
         mock_request.side_effect = err_500
 
         with pytest.raises(requests.exceptions.HTTPError):
-            fetch_image("neo", "26", [ScryfallLanguage.JAPANESE])
+            scryfall.fetch_image("neo", "26", [scryfall.Language.JAPANESE])
 
         assert mock_request.call_count == 1
 
-    @patch('plugins.mtg.scryfall.request_scryfall')
+    @patch('plugins.mtg.scryfall._request_scryfall')
     def test_english_only_does_not_retry_on_404(self, mock_request):
         err_404 = requests.exceptions.HTTPError()
         err_404.response = MagicMock()
@@ -802,17 +703,17 @@ class TestFetchImageLanguageFallback:
         mock_request.side_effect = err_404
 
         with pytest.raises(requests.exceptions.HTTPError):
-            fetch_image("lea", "1", [ScryfallLanguage.ENGLISH])
+            scryfall.fetch_image("lea", "1", [scryfall.Language.ENGLISH])
 
         assert mock_request.call_count == 1
 
-    @patch('plugins.mtg.scryfall.request_scryfall')
+    @patch('plugins.mtg.scryfall._request_scryfall')
     def test_no_langs_falls_back_to_english(self, mock_request):
         english_response = MagicMock()
         english_response.content = b'fake_english_image'
         mock_request.return_value = english_response
 
-        result = fetch_image("lea", "1", None)
+        result = scryfall.fetch_image("lea", "1", [])
 
         assert result == b'fake_english_image'
         url = mock_request.call_args_list[0][0][0]
@@ -822,42 +723,27 @@ class TestFetchImageLanguageFallback:
 class TestFetchCardWithLanguage:
     """Test that fetch_card passes prefer_langs through to fetch_card_art."""
 
-    @patch('plugins.mtg.scryfall.fetch_card_art')
-    @patch('plugins.mtg.scryfall.request_scryfall')
-    def test_prefer_langs_passed_to_fetch_card_art(self, mock_request, mock_fetch_art):
-        shadowspear_with_prints = {**SHADOWSPEAR_JSON, 'prints_search_uri': PRINTS_SEARCH_URI}
-        named_response = MagicMock()
-        named_response.json.return_value = shadowspear_with_prints
-        printings_response = MagicMock()
-        printings_response.json.return_value = {'data': [
-            {**SKRELV_NON_UB_PRINTING, 'set': 'pza', 'collector_number': '17', 'lang': 'ja'},
-        ]}
-        mock_request.side_effect = [named_response, printings_response]
+    @patch('plugins.mtg.scryfall._request_scryfall')
+    def test_prefer_langs_passed_to_fetch_card_art(self, mock_request):
+        skrlev_ub_ja = copy.copy(SKRELV_NON_UB_PRINTING)
+        skrlev_ub_ja.lang = scryfall.Language.JAPANESE
 
-        langs = [ScryfallLanguage.JAPANESE, ScryfallLanguage.GERMAN]
-        fetch_card(1, 1, "", "", False, "Shadowspear",
-                   False, set(), set(), False, False, False, False, langs, False,
-                   front_img_dir='front', double_sided_dir='double_sided')
+        mock_request.side_effect = [
+            _named_response(SKRELV_NON_UB_PRINTING),
+            _printings_response([skrlev_ub_ja]),
+        ]
 
-        args, _ = mock_fetch_art.call_args
-        assert args[8] == langs
+        langs = [scryfall.Language.JAPANESE, scryfall.Language.GERMAN]
+        card = scryfall.fetch_card(
+            name="Shadowspear",
+            prefer_langs=langs,
+        )
 
-    @patch('plugins.mtg.scryfall.fetch_card_art')
-    @patch('plugins.mtg.scryfall.request_scryfall')
-    def test_no_langs_defaults_to_none(self, mock_request, mock_fetch_art):
-        named_response = MagicMock()
-        named_response.json.return_value = SHADOWSPEAR_JSON
-        mock_request.return_value = named_response
-
-        fetch_card(1, 1, "", "", False, "Shadowspear",
-                   False, set(), set(), False, False, False, False, None, False,
-                   front_img_dir='front', double_sided_dir='double_sided')
-
-        args, _ = mock_fetch_art.call_args
-        assert args[8] is None
+        assert card.lang == scryfall.Language.JAPANESE
 
 
 # --- Integration Tests for API and Image Fetching ---
+
 
 @pytest.mark.integration
 class TestScryfallAPI:
@@ -865,10 +751,83 @@ class TestScryfallAPI:
 
     def test_scryfall_api_availability(self):
         """Test that Scryfall API is available and responding."""
-        response = request_scryfall("https://api.scryfall.com/cards/named?exact=Lightning+Bolt")
+        response = _request_scryfall(
+            "https://api.scryfall.com/cards/named?exact=Lightning+Bolt"
+        )
         assert response.status_code == 200
-        json_data = response.json()
-        assert json_data.get('name') == "Lightning Bolt"
+        card = from_json(Card, response.content)
+        assert card.name == "Lightning Bolt"
+
+
+@pytest.mark.integration
+class TestFetchWorkflow:
+    """Integration tests for the fetching workflow. Doesn't write to disk."""
+
+    def test_fetch_single_card_simple_format(self):
+        """Test fetching a single card using simple format."""
+
+        deck_text = "Lightning Bolt"
+        errs, deck = parse_deck(deck_text, DeckFormat.SIMPLE, scryfall.fetch_card)
+        assert not errs
+        assert len(deck) == 1
+        assert list(deck.items())[0][1] == 1
+
+        faces = scryfall.fetch_faces(list(deck.keys())[0])
+        assert faces.back is None  # not a double sided card
+        assert 0 < len(faces.front)
+
+    def test_fetch_double_faced_card(self):
+        """Test fetching a double-faced card."""
+
+        deck_text = "1 Agadeem's Awakening // Agadeem, the Undercrypt (ZNR) 90"
+        errs, deck = parse_deck(deck_text, DeckFormat.MTGA, scryfall.fetch_card)
+        assert not errs
+        assert len(deck) == 1
+        assert list(deck.items())[0][1] == 1
+
+        faces = scryfall.fetch_faces(list(deck.keys())[0])
+        assert faces.back is not None  # double sided card
+        assert 0 < len(faces.front)
+        assert 0 < len(faces.back)
+
+    def test_fetch_flavor_name_card(self):
+        """Cards with flavor names (e.g. convention promos) resolve to the correct card art."""
+        _card = scryfall.fetch_card(name="Donnie's Bō")
+
+    def test_fetch_reversible_card(self):
+        """Fetching a reversible_card saves both the front and back art."""
+
+        # Anointed Procession (SLD) 1511 is a reversible_card layout — same card name/rules on both
+        # sides, but with different artwork. Both faces should be downloaded.
+        deck_text = "1 Anointed Procession (SLD) 1511"
+        errs, deck = parse_deck(deck_text, DeckFormat.MTGA, scryfall.fetch_card)
+        assert not errs
+        assert len(deck) == 1
+
+        faces = scryfall.fetch_faces(list(deck.keys())[0])
+        assert faces.back is not None  # double sided card
+        assert 0 < len(faces.front)
+        assert 0 < len(faces.back)
+
+    def test_fetch_meld_card(self):
+        """Fetching a meld part saves its front art and a cropped half of the combined meld result as the back."""
+        from PIL import Image
+
+        # Bruna, the Fading Light is a meld part whose back is the top half of Brisela, Voice of Nightmares
+        deck_text = "1 Bruna, the Fading Light (EMN) 15"
+        errs, deck = parse_deck(deck_text, DeckFormat.MTGA, scryfall.fetch_card)
+        assert not errs
+        assert len(deck) == 1
+
+        faces = scryfall.fetch_faces(list(deck.keys())[0])
+        assert faces.back is not None  # double sided card
+        assert 0 < len(faces.front)
+        assert 0 < len(faces.back)
+
+        # The saved back image should have full card dimensions (same width as the meld result image)
+        front_img = Image.open(BytesIO(faces.front))
+        back_img = Image.open(BytesIO(faces.back))
+        assert back_img.size == front_img.size
 
 
 @pytest.mark.integration
@@ -884,202 +843,7 @@ class TestFullFetchWorkflow:
         shutil.rmtree(front_dir)
         shutil.rmtree(double_sided_dir)
 
-    def test_fetch_single_card_simple_format(self, temp_dirs):
-        """Test fetching a single card using simple format."""
-        front_dir, double_sided_dir = temp_dirs
-
-        # Use a very small decklist - just 1 card
-        deck_text = "Lightning Bolt"
-
-        handle_card = get_handle_card(
-            ignore_set_and_collector_number=False,
-            prefer_older_sets=False,
-            prefer_sets=[],
-            ignore_sets=[],
-            prefer_showcase=False,
-            prefer_extra_art=False,
-            prefer_ub=False,
-            ignore_ub=False,
-            prefer_langs=None,
-            tokens=False,
-            front_img_dir=front_dir,
-            double_sided_dir=double_sided_dir
-        )
-
-        parse_deck(deck_text, DeckFormat.SIMPLE, handle_card)
-
-        # Check that at least one image was created
-        files = os.listdir(front_dir)
-        assert len(files) >= 1
-
-        # Verify image file has content (> 0 bytes)
-        for f in files:
-            file_path = os.path.join(front_dir, f)
-            assert os.path.getsize(file_path) > 0
-
-    def test_fetch_double_faced_card(self, temp_dirs):
-        """Test fetching a double-faced card."""
-        front_dir, double_sided_dir = temp_dirs
-
-        # Use a modal double-faced card
-        deck_text = "1 Agadeem's Awakening // Agadeem, the Undercrypt (ZNR) 90"
-
-        handle_card = get_handle_card(
-            ignore_set_and_collector_number=False,
-            prefer_older_sets=False,
-            prefer_sets=[],
-            ignore_sets=[],
-            prefer_showcase=False,
-            prefer_extra_art=False,
-            prefer_ub=False,
-            ignore_ub=False,
-            prefer_langs=None,
-            tokens=False,
-            front_img_dir=front_dir,
-            double_sided_dir=double_sided_dir
-        )
-
-        parse_deck(deck_text, DeckFormat.MTGA, handle_card)
-
-        # Check front side was saved
-        front_files = os.listdir(front_dir)
-        assert len(front_files) >= 1
-
-        for f in front_files:
-            file_path = os.path.join(front_dir, f)
-            assert os.path.getsize(file_path) > 0
-
-    def test_fetch_flavor_name_card(self, temp_dirs):
-        """Cards with flavor names (e.g. convention promos) resolve to the correct card art."""
-        front_dir, double_sided_dir = temp_dirs
-
-        handle_card = get_handle_card(
-            ignore_set_and_collector_number=False,
-            prefer_older_sets=False,
-            prefer_sets=[],
-            ignore_sets=[],
-            prefer_showcase=False,
-            prefer_extra_art=False,
-            prefer_ub=False,
-            ignore_ub=False,
-            prefer_langs=None,
-            tokens=False,
-            front_img_dir=front_dir,
-            double_sided_dir=double_sided_dir
-        )
-
-        handle_card(1, "Donnie's Bō", "", "", 1)
-
-        files = os.listdir(front_dir)
-        assert len(files) == 1
-        assert os.path.getsize(os.path.join(front_dir, files[0])) > 0
-
-    def test_fetch_with_quantity(self, temp_dirs):
-        """Test fetching cards with quantity > 1."""
-        front_dir, double_sided_dir = temp_dirs
-
-        deck_text = "2 Lightning Bolt"
-
-        handle_card = get_handle_card(
-            ignore_set_and_collector_number=False,
-            prefer_older_sets=False,
-            prefer_sets=[],
-            ignore_sets=[],
-            prefer_showcase=False,
-            prefer_extra_art=False,
-            prefer_ub=False,
-            ignore_ub=False,
-            prefer_langs=None,
-            tokens=False,
-            front_img_dir=front_dir,
-            double_sided_dir=double_sided_dir
-        )
-
-        parse_deck(deck_text, DeckFormat.MTGO, handle_card)
-
-        # Should have 2 copies of the card
-        files = os.listdir(front_dir)
-        assert len(files) == 2
-
-        for f in files:
-            file_path = os.path.join(front_dir, f)
-            assert os.path.getsize(file_path) > 0
-
-    def test_fetch_reversible_card(self, temp_dirs):
-        """Fetching a reversible_card saves both the front and back art."""
-        front_dir, double_sided_dir = temp_dirs
-
-        # Anointed Procession (SLD) 1511 is a reversible_card layout — same card name/rules on both
-        # sides, but with different artwork. Both faces should be downloaded.
-        deck_text = "1 Anointed Procession (SLD) 1511"
-
-        handle_card = get_handle_card(
-            ignore_set_and_collector_number=False,
-            prefer_older_sets=False,
-            prefer_sets=[],
-            ignore_sets=[],
-            prefer_showcase=False,
-            prefer_extra_art=False,
-            prefer_ub=False,
-            ignore_ub=False,
-            prefer_langs=None,
-            tokens=False,
-            front_img_dir=front_dir,
-            double_sided_dir=double_sided_dir
-        )
-
-        parse_deck(deck_text, DeckFormat.MTGA, handle_card)
-
-        # Front image should be saved
-        front_files = os.listdir(front_dir)
-        assert len(front_files) == 1
-        assert os.path.getsize(os.path.join(front_dir, front_files[0])) > 0
-
-        # Back image should also be saved
-        back_files = os.listdir(double_sided_dir)
-        assert len(back_files) == 1
-        assert os.path.getsize(os.path.join(double_sided_dir, back_files[0])) > 0
-
-    def test_fetch_meld_card(self, temp_dirs):
-        """Fetching a meld part saves its front art and a cropped half of the combined meld result as the back."""
-        from PIL import Image
-        front_dir, double_sided_dir = temp_dirs
-
-        # Bruna, the Fading Light is a meld part whose back is the top half of Brisela, Voice of Nightmares
-        deck_text = "1 Bruna, the Fading Light (EMN) 15"
-
-        handle_card = get_handle_card(
-            ignore_set_and_collector_number=False,
-            prefer_older_sets=False,
-            prefer_sets=[],
-            ignore_sets=[],
-            prefer_showcase=False,
-            prefer_extra_art=False,
-            prefer_ub=False,
-            ignore_ub=False,
-            prefer_langs=None,
-            tokens=False,
-            front_img_dir=front_dir,
-            double_sided_dir=double_sided_dir
-        )
-
-        parse_deck(deck_text, DeckFormat.MTGA, handle_card)
-
-        # Front image of Bruna should be saved
-        front_files = os.listdir(front_dir)
-        assert len(front_files) == 1
-        assert os.path.getsize(os.path.join(front_dir, front_files[0])) > 0
-
-        # Cropped meld result (top half of Brisela, resized to full card) should be in double_sided_dir
-        back_files = os.listdir(double_sided_dir)
-        assert len(back_files) == 1
-        back_path = os.path.join(double_sided_dir, back_files[0])
-        assert os.path.getsize(back_path) > 0
-
-        # The saved back image should have full card dimensions (same width as the meld result image)
-        back_img = Image.open(back_path)
-        front_img = Image.open(os.path.join(front_dir, front_files[0]))
-        assert back_img.size == front_img.size
+    # TODO: add tests for new deck assembly routine
 
 
 @pytest.mark.integration
@@ -1100,8 +864,10 @@ class TestUniverseBeyondScryfallData:
 
     def test_skrelv_has_ub_printing(self):
         """Scryfall still lists a UB printing of Skrelv (SLD 1926)."""
-        printings = fetch_printings(self.SKRELV_PRINTS_URI, None, 'Skrelv, Defector Mite')
-        sets = {p['set'] for p in printings}
+        printings = _fetch_printings(
+            'Skrelv, Defector Mite', self.SKRELV_PRINTS_URI, None
+        )
+        sets = {p.set for p in printings}
         assert 'sld' in sets, (
             "Scryfall no longer lists SLD as a printing of Skrelv. "
             "Update the expected set codes in TestUniverseBeyondFiltering."
@@ -1109,8 +875,10 @@ class TestUniverseBeyondScryfallData:
 
     def test_skrelv_has_non_ub_printing(self):
         """Scryfall still lists a non-UB printing of Skrelv (ONE 225)."""
-        printings = fetch_printings(self.SKRELV_PRINTS_URI, None, 'Skrelv, Defector Mite')
-        sets = {p['set'] for p in printings}
+        printings = _fetch_printings(
+            'Skrelv, Defector Mite', self.SKRELV_PRINTS_URI, None
+        )
+        sets = {p.set for p in printings}
         assert 'one' in sets, (
             "Scryfall no longer lists ONE as a printing of Skrelv. "
             "Update the expected set codes in TestUniverseBeyondFiltering."
@@ -1118,8 +886,12 @@ class TestUniverseBeyondScryfallData:
 
     def test_excalibur_is_ub_only(self):
         """Scryfall lists Excalibur only in UB sets — no non-UB printings exist."""
-        all_printings = fetch_printings(self.EXCALIBUR_PRINTS_URI, None, 'Excalibur, Sword of Eden')
-        non_ub_printings = fetch_printings(self.EXCALIBUR_PRINTS_URI, False, 'Excalibur, Sword of Eden')
+        all_printings = _fetch_printings(
+            'Excalibur, Sword of Eden', self.EXCALIBUR_PRINTS_URI, None
+        )
+        non_ub_printings = _fetch_printings(
+            'Excalibur, Sword of Eden', self.EXCALIBUR_PRINTS_URI, False
+        )
         assert len(non_ub_printings) == len(all_printings), (
             "Excalibur now has a non-UB printing. It can no longer be used as the "
             "UB-only fallback test case — update TestUniverseBeyondFiltering."
@@ -1136,185 +908,144 @@ class TestLanguagePrioritization:
     in English.
     """
 
-    def make_printing(self, set_code, collector_number, lang='en', full_art=False, showcase=False):
+    @staticmethod
+    def make_printing(
+        set_code: SetCode,
+        collector_number: CollectorNumber,
+        lang: scryfall.Language = scryfall.Language.ENGLISH,
+        full_art: bool = False,
+        showcase: bool = False,
+    ):
         """Helper to create a mock printing with specified attributes."""
-        return {
-            'set': set_code,
-            'collector_number': collector_number,
-            'lang': lang,
-            'nonfoil': True,
-            'digital': False,
-            'promo': False,
-            'full_art': full_art,
-            'border_color': 'borderless' if full_art else 'black',
-            'frame_effects': ['showcase'] if showcase else [],
-        }
+        return _mk_card(
+            name='',
+            set=set_code,
+            collector_number=collector_number,
+            border_color=(
+                scryfall.BorderColour.BORDERLESS
+                if full_art
+                else scryfall.BorderColour.BLACK
+            ),
+            frame_effects=[scryfall.FrameEffect.SHOWCASE] if showcase else [],
+            full_art=full_art,
+            lang=lang,
+        )
 
-    @patch('plugins.mtg.scryfall.fetch_card_art')
-    @patch('plugins.mtg.scryfall.request_scryfall')
-    def test_prefer_german_over_english_full_art(self, mock_request, mock_fetch_art):
+    @patch('plugins.mtg.scryfall._request_scryfall')
+    def test_prefer_german_over_english_full_art(self, mock_request):
         """When a card has English full-art and German normal versions, German is selected."""
-        card_json = {
-            'name': 'Lightning Bolt',
-            'set': 'lea',
-            'collector_number': '1',
-            'layout': 'normal',
-            'prints_search_uri': PRINTS_SEARCH_URI,
-        }
-
         printings = [
-            self.make_printing('lea', '1', 'en', full_art=True),   # English full-art
-            self.make_printing('lea', '2', 'de', full_art=False),  # German normal
+            self.make_printing('lea', '1', scryfall.Language.ENGLISH, full_art=True),
+            self.make_printing('lea', '2', scryfall.Language.GERMAN, full_art=False),
+        ]
+        mock_request.side_effect = [
+            _named_response(_mk_card("Lightning Bolt", 'lea', '1')),
+            _printings_response(printings),
         ]
 
-        named_response = MagicMock()
-        named_response.json.return_value = card_json
-        printings_response = MagicMock()
-        printings_response.json.return_value = {'data': printings}
-        mock_request.side_effect = [named_response, printings_response]
-
-        fetch_card(1, 1, "", "", False, "Lightning Bolt",
-                   False, [], [], False, True, False, False,
-                   [ScryfallLanguage.GERMAN], False,
-                   front_img_dir='front', double_sided_dir='double_sided')
+        card = scryfall.fetch_card(
+            name="Lightning Bolt",
+            prefer_extra_art=True,
+            prefer_langs=[scryfall.Language.GERMAN],
+        )
 
         # Should select German printing even though English has full_art
-        args, _ = mock_fetch_art.call_args
-        assert args[3] == 'lea'
-        assert args[4] == '2'  # German version
+        assert card.set == 'lea'
+        assert card.collector_number == '2'  # German version
 
-    @patch('plugins.mtg.scryfall.fetch_card_art')
-    @patch('plugins.mtg.scryfall.request_scryfall')
-    def test_prefer_german_over_english_showcase(self, mock_request, mock_fetch_art):
+    @patch('plugins.mtg.scryfall._request_scryfall')
+    def test_prefer_german_over_english_showcase(self, mock_request):
         """When a card has English showcase and German normal versions, German is selected."""
-        card_json = {
-            'name': 'Sol Ring',
-            'set': 'lea',
-            'collector_number': '1',
-            'layout': 'normal',
-            'prints_search_uri': PRINTS_SEARCH_URI,
-        }
-
         printings = [
-            self.make_printing('lea', '1', 'en', showcase=True),   # English showcase
-            self.make_printing('lea', '2', 'de', showcase=False),  # German normal
+            self.make_printing(
+                'lea', '1', scryfall.Language.ENGLISH, showcase=True
+            ),  # English showcase
+            self.make_printing(
+                'lea', '2', scryfall.Language.GERMAN, showcase=False
+            ),  # German normal
+        ]
+        mock_request.side_effect = [
+            _named_response(_mk_card("Sol Ring", 'lea', '1')),
+            _printings_response(printings),
         ]
 
-        named_response = MagicMock()
-        named_response.json.return_value = card_json
-        printings_response = MagicMock()
-        printings_response.json.return_value = {'data': printings}
-        mock_request.side_effect = [named_response, printings_response]
-
-        fetch_card(1, 1, "", "", False, "Sol Ring",
-                   False, [], [], True, False, False, False,
-                   [ScryfallLanguage.GERMAN], False,
-                   front_img_dir='front', double_sided_dir='double_sided')
+        card = scryfall.fetch_card(
+            name="Sol Ring",
+            prefer_langs=[scryfall.Language.GERMAN],
+            prefer_showcase=True,
+        )
 
         # Should select German printing even though English has showcase
-        args, _ = mock_fetch_art.call_args
-        assert args[3] == 'lea'
-        assert args[4] == '2'  # German version
+        assert card.set == 'lea'
+        assert card.collector_number == '2'  # German version
 
-    @patch('plugins.mtg.scryfall.fetch_card_art')
-    @patch('plugins.mtg.scryfall.request_scryfall')
-    def test_prefer_german_showcase_over_german_normal(self, mock_request, mock_fetch_art):
+    @patch('plugins.mtg.scryfall._request_scryfall')
+    def test_prefer_german_showcase_over_german_normal(self, mock_request):
         """When both German showcase and German normal exist, German showcase is selected."""
-        card_json = {
-            'name': 'Path to Exile',
-            'set': 'lea',
-            'collector_number': '1',
-            'layout': 'normal',
-            'prints_search_uri': PRINTS_SEARCH_URI,
-        }
-
         printings = [
-            self.make_printing('lea', '1', 'en', showcase=True),   # English showcase
-            self.make_printing('lea', '2', 'de', showcase=False),  # German normal
-            self.make_printing('lea', '3', 'de', showcase=True),   # German showcase
+            # English showcase
+            self.make_printing('lea', '1', scryfall.Language.ENGLISH, showcase=True),
+            # German normal
+            self.make_printing('lea', '2', scryfall.Language.GERMAN, showcase=False),
+            # German showcase
+            self.make_printing('lea', '3', scryfall.Language.GERMAN, showcase=True),
+        ]
+        mock_request.side_effect = [
+            _named_response(_mk_card("Path to Exile", 'lea', '1')),
+            _printings_response(printings),
         ]
 
-        named_response = MagicMock()
-        named_response.json.return_value = card_json
-        printings_response = MagicMock()
-        printings_response.json.return_value = {'data': printings}
-        mock_request.side_effect = [named_response, printings_response]
-
-        fetch_card(1, 1, "", "", False, "Path to Exile",
-                   False, [], [], True, False, False, False,
-                   [ScryfallLanguage.GERMAN], False,
-                   front_img_dir='front', double_sided_dir='double_sided')
+        card = scryfall.fetch_card(
+            name="Path to Exile",
+            prefer_langs=[scryfall.Language.GERMAN],
+            prefer_showcase=True,
+        )
 
         # Should select German showcase over German normal
-        args, _ = mock_fetch_art.call_args
-        assert args[3] == 'lea'
-        assert args[4] == '3'  # German showcase
+        assert card.set == 'lea'
+        assert card.collector_number == '3'  # German showcase
 
-    @patch('plugins.mtg.scryfall.fetch_card_art')
-    @patch('plugins.mtg.scryfall.request_scryfall')
-    def test_multiple_prefer_langs_with_priority(self, mock_request, mock_fetch_art):
+    @patch('plugins.mtg.scryfall._request_scryfall')
+    def test_multiple_prefer_langs_with_priority(self, mock_request):
         """When prefer_langs=[GERMAN, FRENCH], German is preferred over French."""
-        card_json = {
-            'name': 'Counterspell',
-            'set': 'lea',
-            'collector_number': '1',
-            'layout': 'normal',
-            'prints_search_uri': PRINTS_SEARCH_URI,
-        }
-
         printings = [
-            self.make_printing('lea', '1', 'en'),  # English
-            self.make_printing('lea', '2', 'fr'),  # French
-            self.make_printing('lea', '3', 'de'),  # German
+            self.make_printing('lea', '1', scryfall.Language.ENGLISH),  # English
+            self.make_printing('lea', '2', scryfall.Language.FRENCH),  # French
+            self.make_printing('lea', '3', scryfall.Language.GERMAN),  # German
         ]
-
-        named_response = MagicMock()
-        named_response.json.return_value = card_json
-        printings_response = MagicMock()
-        printings_response.json.return_value = {'data': printings}
-        mock_request.side_effect = [named_response, printings_response]
-
-        fetch_card(1, 1, "", "", False, "Counterspell",
-                   False, [], [], False, False, False, False,
-                   [ScryfallLanguage.GERMAN, ScryfallLanguage.FRENCH], False,
-                   front_img_dir='front', double_sided_dir='double_sided')
+        mock_request.side_effect = [
+            _named_response(_mk_card("Counterspell", 'lea', '1')),
+            _printings_response(printings),
+        ]
+        card = scryfall.fetch_card(
+            name="Counterspell",
+            prefer_langs=[scryfall.Language.GERMAN, scryfall.Language.FRENCH],
+        )
 
         # Should select German (first in prefer_langs) over French
-        args, _ = mock_fetch_art.call_args
-        assert args[3] == 'lea'
-        assert args[4] == '3'  # German
+        assert card.set == 'lea'
+        assert card.lang == scryfall.Language.GERMAN
 
-    @patch('plugins.mtg.scryfall.fetch_card_art')
-    @patch('plugins.mtg.scryfall.request_scryfall')
-    def test_fallback_to_english_when_preferred_lang_unavailable(self, mock_request, mock_fetch_art):
+    @patch('plugins.mtg.scryfall._request_scryfall')
+    def test_fallback_to_english_when_preferred_lang_unavailable(self, mock_request):
         """When preferred language is unavailable, falls back to English."""
-        card_json = {
-            'name': 'Ancient Tomb',
-            'set': 'lea',
-            'collector_number': '1',
-            'layout': 'normal',
-            'prints_search_uri': PRINTS_SEARCH_URI,
-        }
-
         printings = [
-            self.make_printing('lea', '1', 'en', full_art=True),  # English full-art (only option)
+            # English full-art (only option)
+            self.make_printing('lea', '1', scryfall.Language.ENGLISH, full_art=True),
+        ]
+        mock_request.side_effect = [
+            _named_response(_mk_card("Ancient Tomb", 'lea', '1')),
+            _printings_response(printings),
         ]
 
-        named_response = MagicMock()
-        named_response.json.return_value = card_json
-        printings_response = MagicMock()
-        printings_response.json.return_value = {'data': printings}
-        mock_request.side_effect = [named_response, printings_response]
-
-        fetch_card(1, 1, "", "", False, "Ancient Tomb",
-                   False, [], [], False, True, False, False,
-                   [ScryfallLanguage.GERMAN], False,
-                   front_img_dir='front', double_sided_dir='double_sided')
+        card = scryfall.fetch_card(
+            name="Ancient Tomb",
+            prefer_langs=[scryfall.Language.GERMAN],
+        )
 
         # Should fall back to English when German is unavailable
-        args, _ = mock_fetch_art.call_args
-        assert args[3] == 'lea'
-        assert args[4] == '1'  # English version
+        assert card.set == 'lea'
+        assert card.lang == scryfall.Language.ENGLISH
 
 
 @pytest.mark.integration
@@ -1335,32 +1066,40 @@ class TestUniverseBeyondFiltering:
 
     def test_prefer_ub_returns_only_ub_printings(self):
         """prefer_ub=True returns only Universe Beyond printings of Skrelv."""
-        printings = fetch_printings(self.SKRELV_PRINTS_URI, True, 'Skrelv, Defector Mite')
+        printings = _fetch_printings(
+            'Skrelv, Defector Mite', self.SKRELV_PRINTS_URI, True
+        )
 
-        sets = {p['set'] for p in printings}
+        sets = {p.set for p in printings}
         assert 'sld' in sets
         assert 'one' not in sets
 
     def test_ignore_ub_returns_only_non_ub_printings(self):
         """ignore_ub=True returns only non-Universe Beyond printings of Skrelv."""
-        printings = fetch_printings(self.SKRELV_PRINTS_URI, False, 'Skrelv, Defector Mite')
+        printings = _fetch_printings(
+            'Skrelv, Defector Mite', self.SKRELV_PRINTS_URI, False
+        )
 
-        sets = {p['set'] for p in printings}
+        sets = {p.set for p in printings}
         assert 'sld' not in sets
         assert 'one' in sets
 
     def test_no_filter_returns_all_printings(self):
         """prefer_ub=None returns all printings including both UB and non-UB."""
-        printings = fetch_printings(self.SKRELV_PRINTS_URI, None, 'Skrelv, Defector Mite')
+        printings = _fetch_printings(
+            'Skrelv, Defector Mite', self.SKRELV_PRINTS_URI, None
+        )
 
-        sets = {p['set'] for p in printings}
+        sets = {p.set for p in printings}
         assert 'one' in sets
         assert 'sld' in sets
 
     def test_ignore_ub_falls_back_for_ub_only_card(self):
         """ignore_ub=True falls back to all printings when every printing is UB."""
-        printings = fetch_printings(self.EXCALIBUR_PRINTS_URI, False, 'Excalibur, Sword of Eden')
+        printings = _fetch_printings(
+            'Excalibur, Sword of Eden', self.EXCALIBUR_PRINTS_URI, False
+        )
 
         # Fallback: should still return printings rather than an empty list
         assert len(printings) > 0
-        assert any(p['set'] == 'acr' for p in printings)
+        assert any(p.set == 'acr' for p in printings)

--- a/test/test_mtg_plugin.py
+++ b/test/test_mtg_plugin.py
@@ -7,9 +7,8 @@ import copy
 import shutil
 import tempfile
 import uuid
-from io import BytesIO
-from collections import OrderedDict
 from datetime import datetime
+from io import BytesIO
 from typing import Any, Callable
 from unittest.mock import MagicMock, patch
 
@@ -22,6 +21,7 @@ from plugins.mtg.common import MtgPrintedLanguage
 from plugins.mtg.deck_formats import (
     DeckEntry,
     DeckFormat,
+    DeckList,
     DeckParse,
     FetchCard,
     parse_archidekt,
@@ -55,13 +55,13 @@ def _dummy_fetch_card(
 
 def _verify_deckparse(
     errs: list[tuple[str, Exception]],
-    deck: OrderedDict[Card, int],
+    deck: DeckList,
     expected_cards: list[DeckEntry],
 ):
     assert not errs
     assert len(expected_cards) == len(deck)
     for (name, card_set, collector_number, expected_quantity), (card, quantity) in zip(
-        expected_cards, deck.items()
+        expected_cards, deck
     ):
         assert name == card.name
         assert card_set == card.set
@@ -260,7 +260,8 @@ class TestDeckstatsFormat:
             parse_deckstats,
             deck_text,
             [
-                ("Varragoth, Bloodsky Sire", '', '', 2),
+                ("Varragoth, Bloodsky Sire", '', '', 1),
+                ("Varragoth, Bloodsky Sire", '', '', 1),
             ],
         )
 
@@ -309,7 +310,7 @@ class TestScryfallJsonFormat:
         errors, deck = parse_scryfall_json(deck_text, fetcher)
         assert errors == []
         assert len(deck) == 1
-        deck_card, quantity = list(deck.items())[0]
+        deck_card, quantity = deck[0]
         assert quantity == 1
         assert deck_card == card
 
@@ -770,9 +771,9 @@ class TestFetchWorkflow:
         errs, deck = parse_deck(deck_text, DeckFormat.SIMPLE, scryfall.fetch_card)
         assert not errs
         assert len(deck) == 1
-        assert list(deck.items())[0][1] == 1
+        assert deck[0][1] == 1
 
-        faces = scryfall.fetch_faces(list(deck.keys())[0])
+        faces = scryfall.fetch_faces(deck[0][0])
         assert faces.back is None  # not a double sided card
         assert 0 < len(faces.front)
 
@@ -783,9 +784,9 @@ class TestFetchWorkflow:
         errs, deck = parse_deck(deck_text, DeckFormat.MTGA, scryfall.fetch_card)
         assert not errs
         assert len(deck) == 1
-        assert list(deck.items())[0][1] == 1
+        assert deck[0][1] == 1
 
-        faces = scryfall.fetch_faces(list(deck.keys())[0])
+        faces = scryfall.fetch_faces(deck[0][0])
         assert faces.back is not None  # double sided card
         assert 0 < len(faces.front)
         assert 0 < len(faces.back)
@@ -804,7 +805,7 @@ class TestFetchWorkflow:
         assert not errs
         assert len(deck) == 1
 
-        faces = scryfall.fetch_faces(list(deck.keys())[0])
+        faces = scryfall.fetch_faces(deck[0][0])
         assert faces.back is not None  # double sided card
         assert 0 < len(faces.front)
         assert 0 < len(faces.back)
@@ -819,7 +820,7 @@ class TestFetchWorkflow:
         assert not errs
         assert len(deck) == 1
 
-        faces = scryfall.fetch_faces(list(deck.keys())[0])
+        faces = scryfall.fetch_faces(deck[0][0])
         assert faces.back is not None  # double sided card
         assert 0 < len(faces.front)
         assert 0 < len(faces.back)

--- a/test/test_mtg_plugin.py
+++ b/test/test_mtg_plugin.py
@@ -603,7 +603,7 @@ class TestScryfallFetch:
 
         mock_fetch_art.assert_called_once()
 
-    @patch('plugins.mtg.scryfall.session.get')
+    @patch('plugins.mtg.scryfall.remote._session.get')
     def test_image_fetched_with_lowercase_set_code(self, mock_get):
         """When given an uppercase set code, the image is fetched using the lowercase code returned by the API."""
         info_response = MagicMock(status_code=200)

--- a/utilities.py
+++ b/utilities.py
@@ -343,9 +343,10 @@ def get_directory(path):
     else:
         return os.path.abspath(os.path.dirname(path))
 
-def ensure_directory(path: str) -> str:
+def ensure_directory(path: str | Path) -> Path:
     """Create directory and any missing parent directories. Returns the path."""
-    os.makedirs(path, exist_ok=True)
+    path = Path(path)
+    path.mkdir(exist_ok=True)
     return path
 
 def ensure_output_directory(output_path: str) -> None:


### PR DESCRIPTION
As described in the Discord. Depends on memoised queries for efficiency.
Single-sided tokens are now automatically paired up for printing.
`--tokens` now reports a listing of all used tokens in the given deck-format.

Test suite has been overhauled as well.