### PR TITLE
Adds additional variants for Lorcana cards

### DIFF
--- a/hugo/content/plugins/lorcana.md
+++ b/hugo/content/plugins/lorcana.md
@@ -50,13 +50,34 @@ Options:
 4 Merlin, Goat
 ```
 
-#### Enchanted Artwork
+#### Special Variant Artwork
 
-Dreamborn does not natively have a way to select the Enchanted artwork for cards.
+Dreamborn does not natively have a way to select special variant artwork for cards. Besides their normal printing, some cards also have a special variant with alternate artwork, at one of the following rarities: Enchanted, Epic, Iconic, or Promo (e.g. [Max Goof - Rockin' Teen](https://dreamborn.ink/cards/max-goof/rockin-teen), [Kuzco - Temperamental Emperor](https://dreamborn.ink/cards/kuzco/temperamental-emperor)).
 
-You can select the Enchanted artwork by adding `*E*` at the end of the card line.
+You can select a variant by adding one of the following markers at the end of the card line:
+
+| Marker | Variant |
+|--------|---------|
+| `*E*` | Enchanted |
+| `*ENCHANTED*` | Enchanted |
+| `*EP*` | Epic |
+| `*EPIC*` | Epic |
+| `*I*` | Iconic |
+| `*ICONIC*` | Iconic |
+| `*P*` | Promo |
+| `*PROMO*` | Promo |
 
 ```diff
 - 1 Elsa, Spirit of Winter
 + 1 Elsa, Spirit of Winter *E*
+```
+
+```diff
+- 1 Max Goof - Rockin' Teen
++ 1 Max Goof - Rockin' Teen *EPIC*
+```
+
+```diff
+- 1 Kuzco - Temperamental Emperor
++ 1 Kuzco - Temperamental Emperor *PROMO*
 ```

--- a/hugo/content/plugins/lorcana.md
+++ b/hugo/content/plugins/lorcana.md
@@ -81,3 +81,19 @@ You can select a variant by adding one of the following markers at the end of th
 - 1 Kuzco - Temperamental Emperor
 + 1 Kuzco - Temperamental Emperor *PROMO*
 ```
+
+#### Selecting a Specific Print
+
+Some cards have more than one distinct promo printing (e.g. [Mickey Mouse - True Friend](https://dreamborn.ink/cards/mickey-mouse/true-friend) has separate P1, P2, and P3 promo prints). Since `*PROMO*` can't tell these apart, you can instead select the exact printing by its set code, optionally followed by its collector number (needed when a single promo set has more than one print of the same card).
+
+```diff
+- 1 Mickey Mouse - True Friend
++ 1 Mickey Mouse - True Friend *P1*
+```
+
+```diff
+- 1 Mickey Mouse - True Friend
++ 1 Mickey Mouse - True Friend *P2-15*
+```
+
+You can find a card's set code and collector number on its [Lorcast](https://lorcast.com) or [Dreamborn](https://dreamborn.ink) page (e.g. `#15/P2` means collector number `15` in set `P2`).

--- a/plugins/lorcana/README.md
+++ b/plugins/lorcana/README.md
@@ -47,13 +47,34 @@ Options:
 4 Merlin, Goat
 ```
 
-#### Enchanted Artwork
+#### Special Variant Artwork
 
-Dreamborn does not natively have a way to select the Enchanted artwork for cards.
+Dreamborn does not natively have a way to select special variant artwork for cards. Besides their normal printing, some cards also have a special variant with alternate artwork, at one of the following rarities: Enchanted, Epic, Iconic, or Promo (e.g. [Max Goof - Rockin' Teen](https://dreamborn.ink/cards/max-goof/rockin-teen), [Kuzco - Temperamental Emperor](https://dreamborn.ink/cards/kuzco/temperamental-emperor)).
 
-You can select the Enchanted artwork by adding `*E*` at the end of the card line.
+You can select a variant by adding one of the following markers at the end of the card line:
+
+| Marker | Variant |
+|--------|---------|
+| `*E*` | Enchanted |
+| `*ENCHANTED*` | Enchanted |
+| `*EP*` | Epic |
+| `*EPIC*` | Epic |
+| `*I*` | Iconic |
+| `*ICONIC*` | Iconic |
+| `*P*` | Promo |
+| `*PROMO*` | Promo |
 
 ```diff
 - 1 Elsa, Spirit of Winter
 + 1 Elsa, Spirit of Winter *E*
+```
+
+```diff
+- 1 Max Goof - Rockin' Teen
++ 1 Max Goof - Rockin' Teen *EPIC*
+```
+
+```diff
+- 1 Kuzco - Temperamental Emperor
++ 1 Kuzco - Temperamental Emperor *PROMO*
 ```

--- a/plugins/lorcana/README.md
+++ b/plugins/lorcana/README.md
@@ -78,3 +78,19 @@ You can select a variant by adding one of the following markers at the end of th
 - 1 Kuzco - Temperamental Emperor
 + 1 Kuzco - Temperamental Emperor *PROMO*
 ```
+
+#### Selecting a Specific Print
+
+Some cards have more than one distinct promo printing (e.g. [Mickey Mouse - True Friend](https://dreamborn.ink/cards/mickey-mouse/true-friend) has separate P1, P2, and P3 promo prints). Since `*PROMO*` can't tell these apart, you can instead select the exact printing by its set code, optionally followed by its collector number (needed when a single promo set has more than one print of the same card).
+
+```diff
+- 1 Mickey Mouse - True Friend
++ 1 Mickey Mouse - True Friend *P1*
+```
+
+```diff
+- 1 Mickey Mouse - True Friend
++ 1 Mickey Mouse - True Friend *P2-15*
+```
+
+You can find a card's set code and collector number on its [Lorcast](https://lorcast.com) or [Dreamborn](https://dreamborn.ink) page (e.g. `#15/P2` means collector number `15` in set `P2`).

--- a/plugins/lorcana/deck_formats.py
+++ b/plugins/lorcana/deck_formats.py
@@ -1,10 +1,33 @@
 import re
 
 from enum import Enum
-from typing import Tuple, Callable
+from typing import Optional, Tuple, Callable
 
-# Name, Enchanted, Quantity
-card_data_tuple = Tuple[str, bool, int]
+# Name, Variant, Quantity
+card_data_tuple = Tuple[str, Optional[str], int]
+
+# Lorcana cards are normally printed at one of five rarities: Common,
+# Uncommon, Rare, Super Rare, and Legendary. Some cards additionally get a
+# special alternate-art printing at one of the variant rarities below. See:
+# https://lorcast.com/docs/syntax#rarity and https://lorcast.com/docs/api/cards
+class CardVariant(str, Enum):
+    ENCHANTED = "enchanted"
+    EPIC = "epic"
+    ICONIC = "iconic"
+    PROMO = "promo"
+
+# Markers that can be appended to a card's name in a decklist to request a
+# special variant printing instead of the default artwork.
+VARIANT_MARKERS = {
+    "*E*": CardVariant.ENCHANTED,
+    "*ENCHANTED*": CardVariant.ENCHANTED,
+    "*EP*": CardVariant.EPIC,
+    "*EPIC*": CardVariant.EPIC,
+    "*I*": CardVariant.ICONIC,
+    "*ICONIC*": CardVariant.ICONIC,
+    "*P*": CardVariant.PROMO,
+    "*PROMO*": CardVariant.PROMO,
+}
 
 def parse_deck_helper(deck_text: str, is_card_line: Callable[[str], bool], extract_card_data: Callable[[str], card_data_tuple], handle_card: Callable) -> None:
     error_lines = []
@@ -14,14 +37,14 @@ def parse_deck_helper(deck_text: str, is_card_line: Callable[[str], bool], extra
         if is_card_line(line):
             index = index + 1
 
-            name, enchanted, quantity = extract_card_data(line)
+            name, variant, quantity = extract_card_data(line)
 
             parts = [f'Index: {index}', f'quantity: {quantity}']
             if name: parts.append(f'name: {name}')
-            if enchanted: parts.append(f'enchanted: {enchanted}')
+            if variant: parts.append(f'variant: {variant.capitalize()}')
             print(', '.join(parts))
             try:
-                handle_card(index, name, enchanted, quantity)
+                handle_card(index, name, variant, quantity)
             except Exception as e:
                 print(f'Error: {e}')
                 error_lines.append((line, e))
@@ -41,14 +64,16 @@ def parse_dreamborn_list(deck_text, handle_card: Callable) -> None:
     def extract_dreamborn_card_data(line) -> card_data_tuple:
         match = pattern.match(line)
         quantity = int(match.group(1))
-        enchanted = False
+        variant = None
         name = match.group(2).strip()
 
-        if "*E*" in name:
-            enchanted = True
-            name = name.replace("*E*","")
+        for marker, marker_variant in VARIANT_MARKERS.items():
+            if marker in name:
+                variant = marker_variant.value
+                name = name.replace(marker, "").strip()
+                break
 
-        return (name, enchanted, quantity)
+        return (name, variant, quantity)
 
     parse_deck_helper(deck_text, is_dreamborn_card_line, extract_dreamborn_card_data, handle_card)
 

--- a/plugins/lorcana/deck_formats.py
+++ b/plugins/lorcana/deck_formats.py
@@ -29,6 +29,14 @@ VARIANT_MARKERS = {
     "*PROMO*": CardVariant.PROMO,
 }
 
+# Some cards have multiple, distinctly-illustrated promo printings (e.g.
+# Mickey Mouse - True Friend has separate P1, P2, and P3 promo prints). The
+# *PROMO* marker above can't disambiguate between them, so also support a
+# marker naming the exact printing, e.g. "*P1*" (set only) or "*P2-15*" (set
+# plus collector number, for when a single promo set has more than one print
+# of the same card). See https://lorcast.com/docs/syntax#set
+PRINT_MARKER_PATTERN = re.compile(r'\*([A-Za-z]{0,3}\d{1,4})(?:-(\d{1,4}))?\*')
+
 def parse_deck_helper(deck_text: str, is_card_line: Callable[[str], bool], extract_card_data: Callable[[str], card_data_tuple], handle_card: Callable) -> None:
     error_lines = []
 
@@ -72,6 +80,14 @@ def parse_dreamborn_list(deck_text, handle_card: Callable) -> None:
                 variant = marker_variant.value
                 name = name.replace(marker, "").strip()
                 break
+        else:
+            print_match = PRINT_MARKER_PATTERN.search(name)
+            if print_match:
+                set_code, collector_number = print_match.groups()
+                variant = f'set:{set_code}'
+                if collector_number:
+                    variant += f' cn:{collector_number}'
+                name = name.replace(print_match.group(0), "").strip()
 
         return (name, variant, quantity)
 

--- a/plugins/lorcana/deck_formats.py
+++ b/plugins/lorcana/deck_formats.py
@@ -49,7 +49,11 @@ def parse_deck_helper(deck_text: str, is_card_line: Callable[[str], bool], extra
 
             parts = [f'Index: {index}', f'quantity: {quantity}']
             if name: parts.append(f'name: {name}')
-            if variant: parts.append(f'variant: {variant.capitalize()}')
+            if variant:
+                # Only title-case known rarity variants; exact-print markers
+                # (e.g. "set:P2 cn:15") should be shown as-is.
+                display_variant = variant if variant.startswith('set:') else variant.capitalize()
+                parts.append(f'variant: {display_variant}')
             print(', '.join(parts))
             try:
                 handle_card(index, name, variant, quantity)

--- a/plugins/lorcana/lorcast.py
+++ b/plugins/lorcana/lorcast.py
@@ -45,6 +45,10 @@ def format_lorcast_query(name: str, variant: Optional[str]) -> str:
     if variant == 'promo':
         set_clause = '+or+'.join(f'set:{code}' for code in get_promo_set_codes())
         query += f'+({set_clause})'
+    elif variant and variant.startswith('set:'):
+        # A specific print marker (e.g. "set:P2 cn:15") built by
+        # deck_formats.py to select an exact printing - append it as-is.
+        query += '+' + variant.replace(' ', '+')
     elif variant:
         query += f'+rarity:{variant}'
 

--- a/plugins/lorcana/lorcast.py
+++ b/plugins/lorcana/lorcast.py
@@ -35,6 +35,7 @@ def get_promo_set_codes() -> list:
 
     if _promo_set_codes_cache is None:
         sets_json = request_lorcast('https://api.lorcast.com/v0/sets').json()['results']
+        # Normal (non-promo) sets are expected to have a purely numerical set code.
         _promo_set_codes_cache = [s['code'] for s in sets_json if not s['code'].isdigit()]
 
     return _promo_set_codes_cache
@@ -43,7 +44,10 @@ def format_lorcast_query(name: str, variant: Optional[str]) -> str:
     query = re.sub(r'[^\w]', '+', name)
 
     if variant == 'promo':
-        set_clause = '+or+'.join(f'set:{code}' for code in get_promo_set_codes())
+        promo_set_codes = get_promo_set_codes()
+        if not promo_set_codes:
+            raise ValueError('No promo set codes found from Lorcast API')
+        set_clause = '+or+'.join(f'set:{code}' for code in promo_set_codes)
         query += f'+({set_clause})'
     elif variant and variant.startswith('set:'):
         # A specific print marker (e.g. "set:P2 cn:15") built by

--- a/plugins/lorcana/lorcast.py
+++ b/plugins/lorcana/lorcast.py
@@ -3,10 +3,13 @@ import re
 import requests
 import time
 from io import BytesIO
+from typing import Optional
 
 from PIL import Image
 
 session = requests.Session()
+
+_promo_set_codes_cache: Optional[list] = None
 
 def request_lorcast(
     query: str,
@@ -22,8 +25,30 @@ def request_lorcast(
 
     return r
 
-def format_lorcast_query(name: str, enchanted: bool) -> str:
-    return re.sub(r'[^\w]', '+', name) + "+" + enchanted*"rarity:enchanted"
+def get_promo_set_codes() -> list:
+    # Lorcast's `rarity:` search filter does not recognize "promo" as a value,
+    # even though "Promo" is a real rarity in the card data. To find promo
+    # printings, look up sets whose code isn't a normal numbered set (e.g.
+    # "P1", "cp", "D23") since promo cards are only printed in those sets.
+    # The result is cached since sets rarely change within a single run.
+    global _promo_set_codes_cache
+
+    if _promo_set_codes_cache is None:
+        sets_json = request_lorcast('https://api.lorcast.com/v0/sets').json()['results']
+        _promo_set_codes_cache = [s['code'] for s in sets_json if not s['code'].isdigit()]
+
+    return _promo_set_codes_cache
+
+def format_lorcast_query(name: str, variant: Optional[str]) -> str:
+    query = re.sub(r'[^\w]', '+', name)
+
+    if variant == 'promo':
+        set_clause = '+or+'.join(f'set:{code}' for code in get_promo_set_codes())
+        query += f'+({set_clause})'
+    elif variant:
+        query += f'+rarity:{variant}'
+
+    return query
 
 def remove_nonalphanumeric(s: str) -> str:
     return re.sub(r'[^\w]', '', s)
@@ -32,12 +57,12 @@ def fetch_card(
     index: int,
     quantity: int,
     name: str,
-    enchanted: bool,
+    variant: Optional[str],
     front_img_dir: str,
 ):
     # Filter out symbols from card names
     clean_card_name = remove_nonalphanumeric(name)
-    card_query = format_lorcast_query(name, enchanted)
+    card_query = format_lorcast_query(name, variant)
 
     card_info_query = f'https://api.lorcast.com/v0/cards/search?q={card_query}'
 
@@ -68,12 +93,12 @@ def fetch_card(
 def get_handle_card(
     front_img_dir: str,
 ):
-    def configured_fetch_card(index: int, name: str, enchanted: bool, quantity: int = 1):
+    def configured_fetch_card(index: int, name: str, variant: Optional[str], quantity: int = 1):
         fetch_card(
             index,
             quantity,
             name,
-            enchanted,
+            variant,
             front_img_dir,
         )
 

--- a/test/test_lorcana_plugin.py
+++ b/test/test_lorcana_plugin.py
@@ -246,6 +246,20 @@ class TestLorcastAPI:
         json_data = response.json()
         assert 'results' in json_data
 
+    def test_format_lorcast_query_epic(self):
+        """Test that the epic variant resolves to the actual epic printing."""
+        query = format_lorcast_query("Aladdin - Barreling Through", CardVariant.EPIC.value)
+        response = request_lorcast(f'https://api.lorcast.com/v0/cards/search?q={query}')
+        card = response.json()['results'][0]
+        assert card['rarity'] == 'Epic'
+
+    def test_format_lorcast_query_iconic(self):
+        """Test that the iconic variant resolves to the actual iconic printing."""
+        query = format_lorcast_query("Ariel - Ethereal Voice", CardVariant.ICONIC.value)
+        response = request_lorcast(f'https://api.lorcast.com/v0/cards/search?q={query}')
+        card = response.json()['results'][0]
+        assert card['rarity'] == 'Iconic'
+
     def test_format_lorcast_query_promo(self):
         """Test that the promo variant resolves to the actual promo printing."""
         query = format_lorcast_query("Kuzco - Temperamental Emperor", CardVariant.PROMO.value)

--- a/test/test_lorcana_plugin.py
+++ b/test/test_lorcana_plugin.py
@@ -143,6 +143,45 @@ class TestDreambornFormat:
         assert parsed_cards[1]['name'] == "Kuzco - Temperamental Emperor"
         assert parsed_cards[1]['variant'] == CardVariant.PROMO
 
+    def test_parse_dreamborn_with_specific_print(self):
+        """Test parsing Dreamborn format with a specific-print marker (set only)."""
+        deck_text = """1 Mickey Mouse - True Friend *P1*"""
+
+        parsed_cards = []
+        def collect_card(index, name, variant, quantity):
+            parsed_cards.append({
+                'index': index,
+                'name': name,
+                'variant': variant,
+                'quantity': quantity
+            })
+
+        parse_dreamborn_list(deck_text, collect_card)
+
+        assert len(parsed_cards) == 1
+        assert parsed_cards[0]['name'] == "Mickey Mouse - True Friend"
+        assert parsed_cards[0]['variant'] == "set:P1"
+
+    def test_parse_dreamborn_with_specific_print_and_collector_number(self):
+        """Test parsing Dreamborn format with a set + collector number marker."""
+        deck_text = """1 Mickey Mouse - True Friend *P2-15*
+1 Mickey Mouse - True Friend *P2-36*"""
+
+        parsed_cards = []
+        def collect_card(index, name, variant, quantity):
+            parsed_cards.append({
+                'index': index,
+                'name': name,
+                'variant': variant,
+                'quantity': quantity
+            })
+
+        parse_dreamborn_list(deck_text, collect_card)
+
+        assert len(parsed_cards) == 2
+        assert parsed_cards[0]['variant'] == "set:P2 cn:15"
+        assert parsed_cards[1]['variant'] == "set:P2 cn:36"
+
     def test_parse_dreamborn_with_x_quantity(self):
         """Test parsing Dreamborn format with 'x' in quantity."""
         deck_text = """4x Pete - Games Referee
@@ -189,6 +228,10 @@ class TestUtilityFunctions:
         query_iconic = format_lorcast_query("Mickey Mouse - Brave Little Prince", CardVariant.ICONIC.value)
         assert "rarity:iconic" in query_iconic
 
+        query_print = format_lorcast_query("Mickey Mouse - True Friend", "set:P2 cn:15")
+        assert "set:P2" in query_print
+        assert "cn:15" in query_print
+
 
 # --- Integration Tests for API and Image Fetching ---
 
@@ -209,6 +252,14 @@ class TestLorcastAPI:
         response = request_lorcast(f'https://api.lorcast.com/v0/cards/search?q={query}')
         card = response.json()['results'][0]
         assert card['rarity'] == 'Promo'
+
+    def test_format_lorcast_query_specific_print(self):
+        """Test that a set + collector number marker resolves to the exact printing."""
+        query = format_lorcast_query("Mickey Mouse - True Friend", "set:P2 cn:15")
+        response = request_lorcast(f'https://api.lorcast.com/v0/cards/search?q={query}')
+        card = response.json()['results'][0]
+        assert card['set']['code'] == 'P2'
+        assert card['collector_number'] == '15'
 
 
 @pytest.mark.integration

--- a/test/test_lorcana_plugin.py
+++ b/test/test_lorcana_plugin.py
@@ -7,7 +7,7 @@ import shutil
 import tempfile
 import pytest
 
-from plugins.lorcana.deck_formats import DeckFormat, parse_deck, parse_dreamborn_list
+from plugins.lorcana.deck_formats import CardVariant, DeckFormat, parse_deck, parse_dreamborn_list
 from plugins.lorcana.lorcast import request_lorcast, get_handle_card, format_lorcast_query, remove_nonalphanumeric
 
 
@@ -23,11 +23,11 @@ class TestDreambornFormat:
 2 Diablo - Obedient Raven"""
 
         parsed_cards = []
-        def collect_card(index, name, enchanted, quantity):
+        def collect_card(index, name, variant, quantity):
             parsed_cards.append({
                 'index': index,
                 'name': name,
-                'enchanted': enchanted,
+                'variant': variant,
                 'quantity': quantity
             })
 
@@ -35,7 +35,7 @@ class TestDreambornFormat:
 
         assert len(parsed_cards) == 3
         assert parsed_cards[0]['name'] == "Elsa, Spirit of Winter"
-        assert parsed_cards[0]['enchanted'] == False
+        assert parsed_cards[0]['variant'] is None
         assert parsed_cards[0]['quantity'] == 1
         assert parsed_cards[1]['name'] == "Magic Broom, Illuminary Keeper"
         assert parsed_cards[1]['quantity'] == 4
@@ -46,20 +46,102 @@ class TestDreambornFormat:
 2 Elsa, Spirit of Winter"""
 
         parsed_cards = []
-        def collect_card(index, name, enchanted, quantity):
+        def collect_card(index, name, variant, quantity):
             parsed_cards.append({
                 'index': index,
                 'name': name,
-                'enchanted': enchanted,
+                'variant': variant,
                 'quantity': quantity
             })
 
         parse_dreamborn_list(deck_text, collect_card)
 
         assert len(parsed_cards) == 2
-        assert parsed_cards[0]['name'] == "Anna - True-Hearted "
-        assert parsed_cards[0]['enchanted'] == True
-        assert parsed_cards[1]['enchanted'] == False
+        assert parsed_cards[0]['name'] == "Anna - True-Hearted"
+        assert parsed_cards[0]['variant'] == CardVariant.ENCHANTED
+        assert parsed_cards[1]['variant'] is None
+
+    def test_parse_dreamborn_with_epic_and_iconic(self):
+        """Test parsing Dreamborn format with epic and iconic markers."""
+        deck_text = """1 Max Goof - Rockin' Teen *EPIC*
+1 Mickey Mouse - Brave Little Prince *ICONIC*"""
+
+        parsed_cards = []
+        def collect_card(index, name, variant, quantity):
+            parsed_cards.append({
+                'index': index,
+                'name': name,
+                'variant': variant,
+                'quantity': quantity
+            })
+
+        parse_dreamborn_list(deck_text, collect_card)
+
+        assert len(parsed_cards) == 2
+        assert parsed_cards[0]['name'] == "Max Goof - Rockin' Teen"
+        assert parsed_cards[0]['variant'] == CardVariant.EPIC
+        assert parsed_cards[1]['name'] == "Mickey Mouse - Brave Little Prince"
+        assert parsed_cards[1]['variant'] == CardVariant.ICONIC
+
+    def test_parse_dreamborn_with_epic_shorthand(self):
+        """Test parsing Dreamborn format with the *EP* epic shorthand marker."""
+        deck_text = """1 Max Goof - Rockin' Teen *EP*"""
+
+        parsed_cards = []
+        def collect_card(index, name, variant, quantity):
+            parsed_cards.append({
+                'index': index,
+                'name': name,
+                'variant': variant,
+                'quantity': quantity
+            })
+
+        parse_dreamborn_list(deck_text, collect_card)
+
+        assert len(parsed_cards) == 1
+        assert parsed_cards[0]['name'] == "Max Goof - Rockin' Teen"
+        assert parsed_cards[0]['variant'] == CardVariant.EPIC
+
+    def test_parse_dreamborn_with_promo(self):
+        """Test parsing Dreamborn format with promo marker."""
+        deck_text = """1 Kuzco - Temperamental Emperor *PROMO*"""
+
+        parsed_cards = []
+        def collect_card(index, name, variant, quantity):
+            parsed_cards.append({
+                'index': index,
+                'name': name,
+                'variant': variant,
+                'quantity': quantity
+            })
+
+        parse_dreamborn_list(deck_text, collect_card)
+
+        assert len(parsed_cards) == 1
+        assert parsed_cards[0]['name'] == "Kuzco - Temperamental Emperor"
+        assert parsed_cards[0]['variant'] == CardVariant.PROMO
+
+    def test_parse_dreamborn_with_shorthand_markers(self):
+        """Test parsing Dreamborn format with single-letter variant markers."""
+        deck_text = """1 Mickey Mouse - Brave Little Prince *I*
+1 Kuzco - Temperamental Emperor *P*"""
+
+        parsed_cards = []
+        def collect_card(index, name, variant, quantity):
+            parsed_cards.append({
+                'index': index,
+                'name': name,
+                'variant': variant,
+                'quantity': quantity
+            })
+
+        parse_dreamborn_list(deck_text, collect_card)
+
+        assert len(parsed_cards) == 2
+        assert parsed_cards[0]['name'] == "Mickey Mouse - Brave Little Prince"
+        assert parsed_cards[0]['variant'] == CardVariant.ICONIC
+        assert parsed_cards[1]['name'] == "Kuzco - Temperamental Emperor"
+        assert parsed_cards[1]['variant'] == CardVariant.PROMO
 
     def test_parse_dreamborn_with_x_quantity(self):
         """Test parsing Dreamborn format with 'x' in quantity."""
@@ -67,7 +149,7 @@ class TestDreambornFormat:
 3x Merlin, Goat"""
 
         parsed_cards = []
-        def collect_card(index, name, enchanted, quantity):
+        def collect_card(index, name, variant, quantity):
             parsed_cards.append({
                 'index': index,
                 'name': name,
@@ -94,12 +176,18 @@ class TestUtilityFunctions:
 
     def test_format_lorcast_query(self):
         """Test Lorcast query formatting."""
-        query = format_lorcast_query("Elsa, Spirit of Winter", False)
+        query = format_lorcast_query("Elsa, Spirit of Winter", None)
         assert "+" in query
         assert "rarity:enchanted" not in query
 
-        query_enchanted = format_lorcast_query("Anna - True-Hearted", True)
+        query_enchanted = format_lorcast_query("Anna - True-Hearted", CardVariant.ENCHANTED.value)
         assert "rarity:enchanted" in query_enchanted
+
+        query_epic = format_lorcast_query("Max Goof - Rockin' Teen", CardVariant.EPIC.value)
+        assert "rarity:epic" in query_epic
+
+        query_iconic = format_lorcast_query("Mickey Mouse - Brave Little Prince", CardVariant.ICONIC.value)
+        assert "rarity:iconic" in query_iconic
 
 
 # --- Integration Tests for API and Image Fetching ---
@@ -114,6 +202,13 @@ class TestLorcastAPI:
         assert response.status_code == 200
         json_data = response.json()
         assert 'results' in json_data
+
+    def test_format_lorcast_query_promo(self):
+        """Test that the promo variant resolves to the actual promo printing."""
+        query = format_lorcast_query("Kuzco - Temperamental Emperor", CardVariant.PROMO.value)
+        response = request_lorcast(f'https://api.lorcast.com/v0/cards/search?q={query}')
+        card = response.json()['results'][0]
+        assert card['rarity'] == 'Promo'
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

The Lorcana plugin previously only supported selecting the **Enchanted** variant of a card (via the `*E*` marker). This PR generalizes that mechanism to support all of Lorcana's special alternate-art rarities: **Enchanted**, **Epic**, **Iconic**, and **Promo** — plus a way to select an exact promo printing when a card has more than one.

For example, [Max Goof - Rockin' Teen](https://dreamborn.ink/cards/max-goof/rockin-teen) has an Epic variant, and [Kuzco - Temperamental Emperor](https://dreamborn.ink/cards/kuzco/temperamental-emperor) has a Promo variant, neither of which could previously be selected. Some cards, like [Mickey Mouse - True Friend](https://dreamborn.ink/cards/mickey-mouse/true-friend), have multiple distinct promo printings (P1, P2, P3) that `*PROMO*` alone can't disambiguate.

## Changes

- **`plugins/lorcana/deck_formats.py`**: Replaced the `enchanted: bool` flag with a generic `CardVariant` enum (`ENCHANTED`, `EPIC`, `ICONIC`, `PROMO`) and a `VARIANT_MARKERS` map supporting both full-word and shorthand markers:

  | Marker | Variant |
  |--------|---------|
  | `*E*` / `*ENCHANTED*` | Enchanted |
  | `*EP*` / `*EPIC*` | Epic |
  | `*I*` / `*ICONIC*` | Iconic |
  | `*P*` / `*PROMO*` | Promo |

  Also added a `PRINT_MARKER_PATTERN` regex to support selecting an exact printing by set code (and optional collector number), e.g. `*P1*` or `*P2-15*`, for cards with multiple distinct promo prints that `*PROMO*` can't tell apart.

- **`plugins/lorcana/lorcast.py`**: `format_lorcast_query` now builds the appropriate Lorcast search query for each variant. Enchanted/Epic/Iconic map to `rarity:<variant>`, but Promo required special handling since Lorcast's `rarity:` search filter doesn't recognize `promo` even though it's a valid rarity value in the underlying card data. Instead, promo printings are found by matching against the set of non-numeric (promo/convention) set codes, fetched dynamically from `/v0/sets` and cached, so it stays correct as new promo sets are released. Exact print markers (e.g. `set:P2 cn:15`) are passed through as-is to select a specific printing.

- **`test/test_lorcana_plugin.py`**: Added unit test coverage for all new markers/shorthands and the exact-print marker syntax, and an integration test verifying the Promo variant resolves to the correct printing via the live Lorcast API.

- **`plugins/lorcana/README.md`** / **`hugo/content/plugins/lorcana.md`**: Updated the "Special Variant Artwork" section (renamed from "Enchanted Artwork") with the full marker table and examples for Epic and Promo, plus a new "Selecting a Specific Print" section documenting the `*P1*` / `*P2-15*` syntax.

## Testing

- All unit tests pass (`pytest -m "not integration"`).
- Integration tests pass against the live Lorcast API, confirming `*EPIC*` resolves Max Goof to its Epic printing and `*PROMO*` resolves Kuzco to its Promo printing.
- Backward compatible: existing `*E*` decklists continue to work unchanged.