### PR TITLE
feat(plugins): add KeyForge card fetcher plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,6 @@ This file provides context for AI coding assistants working on this project.
 **Silhouette Card Maker** is a collection of tools and cutting templates for utilizing Silhouette cutting machines to cut cards. Users can create DIY card games or proxies for various trading card games (TCGs).
 
 The project consists of:
-
 - Python scripts for PDF generation and offset calibration
 - Silhouette Studio cutting templates
 - Plugins for fetching card images from various TCG databases
@@ -52,11 +51,11 @@ silhouette-card-maker/
 
 When documentation changes are made, similar changes need to be made in both locations:
 
-| README.md Section          | Hugo Content Location            |
-| -------------------------- | -------------------------------- |
-| Root README.md             | `hugo/content/_index.md`         |
-| `create_pdf.py` docs       | `hugo/content/docs/create.md`    |
-| `offset_pdf.py` docs       | `hugo/content/docs/offset.md`    |
+| README.md Section | Hugo Content Location |
+|-------------------|----------------------|
+| Root README.md | `hugo/content/_index.md` |
+| `create_pdf.py` docs | `hugo/content/docs/create.md` |
+| `offset_pdf.py` docs | `hugo/content/docs/offset.md` |
 | `plugins/<game>/README.md` | `hugo/content/plugins/<game>.md` |
 
 The Hugo site is deployed to: https://alan-cha.github.io/silhouette-card-maker
@@ -67,43 +66,41 @@ The Hugo site is deployed to: https://alan-cha.github.io/silhouette-card-maker
 
 Run by end users as part of the normal card-making workflow.
 
-| Script          | Purpose                                                                         |
-| --------------- | ------------------------------------------------------------------------------- |
-| `create_pdf.py` | Lay out card images into a print-ready PDF with registration marks              |
+| Script | Purpose |
+|--------|---------|
+| `create_pdf.py` | Lay out card images into a print-ready PDF with registration marks |
 | `offset_pdf.py` | Add x/y/angle offset to a PDF to compensate for printer front/back misalignment |
-| `clean_up.py`   | Delete all images from `game/front/` and `game/double_sided/` to start fresh    |
+| `clean_up.py` | Delete all images from `game/front/` and `game/double_sided/` to start fresh |
 
 ### Developer/maintainer tools
 
 Run by maintainers to regenerate project artifacts. Not needed for normal card-making use.
 
-| Script                      | Purpose                                                                                                                                                 |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `generate_calibration.py`   | Generate calibration PDFs for all paper sizes                                                                                                           |
-| `generate_dxf.py`           | Generate DXF cutting templates from `assets/layouts.json`                                                                                               |
-| `dxf_to_studio3.py`         | Convert DXF files to Silhouette Studio `.studio3` format; subcommands: `convert` (single file), `batch` (all DXFs), `calibrate` (record UI coordinates) |
-| `generate_readme_tables.py` | Regenerate the card/paper size tables in `README.md` and Hugo docs                                                                                      |
+| Script | Purpose |
+|--------|---------|
+| `generate_calibration.py` | Generate calibration PDFs for all paper sizes |
+| `generate_dxf.py` | Generate DXF cutting templates from `assets/layouts.json` |
+| `dxf_to_studio3.py` | Convert DXF files to Silhouette Studio `.studio3` format; subcommands: `convert` (single file), `batch` (all DXFs), `calibrate` (record UI coordinates) |
+| `generate_readme_tables.py` | Regenerate the card/paper size tables in `README.md` and Hugo docs |
 
 ### Internal modules
 
 Imported by other scripts. Not intended to be run directly.
 
-| Module            | Purpose                                                                          |
-| ----------------- | -------------------------------------------------------------------------------- |
-| `utilities.py`    | Shared data loading: `LayoutConfig`, `load_layout_config`, `template_name`, etc. |
-| `enums.py`        | Shared enums: `Orientation`                                                      |
-| `size_convert.py` | Unit conversion utilities (pixels, mm, inches)                                   |
-| `page_manager.py` | Card layout and page geometry calculations                                       |
-| `dxf_manager.py`  | DXF file generation utilities                                                    |
+| Module | Purpose |
+|--------|---------|
+| `utilities.py` | Shared data loading: `LayoutConfig`, `load_layout_config`, `template_name`, etc. |
+| `enums.py` | Shared enums: `Orientation` |
+| `size_convert.py` | Unit conversion utilities (pixels, mm, inches) |
+| `page_manager.py` | Card layout and page geometry calculations |
+| `dxf_manager.py` | DXF file generation utilities |
 
 ### Key Script Details
 
 #### create_pdf.py
-
 Creates PDFs with card layouts and registration marks for cutting. Supports multiple card sizes (standard, japanese, poker, bridge, tarot, etc.) and paper sizes (letter, tabloid, a4, a3, arch_b).
 
 Key options:
-
 - `--card_size` / `--paper_size`: Card and paper dimensions
 - `--extend_corners`: Fix artifacts from rounded corner images
 - `--crop`: Crop existing print bleed from images
@@ -111,11 +108,9 @@ Key options:
 - `--skip`: Skip cards near registration marks
 
 #### offset_pdf.py
-
 Adds offset to every other page in a PDF to compensate for printer front/back misalignment. Supports x/y offset and angle rotation.
 
 Key options:
-
 - `--x_offset` / `--y_offset`: Pixel offset values
 - `--angle`: Rotational offset in degrees
 - `--save`: Persist offset values for future use
@@ -134,7 +129,7 @@ plugins/<game>/
 
 Plugins read decklists and download card images to `game/front/` (and `game/double_sided/` for double-faced cards).
 
-Supported games include: MTG, Yu-Gi-Oh!, Pokemon, Lorcana, Digimon, One Piece, Flesh and Blood, Star Wars: Unlimited, Grand Archive, Gundam, KeyForge, Netrunner, Altered, Ashes Reborn, Elestrals, and Riftbound.
+Supported games include: MTG, Yu-Gi-Oh!, Pokemon, Lorcana, Digimon, One Piece, Flesh and Blood, Star Wars: Unlimited, Grand Archive, Gundam, Netrunner, KeyForge, Altered, Ashes Reborn, Elestrals, and Riftbound.
 
 ## Development Setup
 
@@ -165,14 +160,14 @@ The theme is included as a git submodule in `hugo/themes/hextra/`.
 
 ## Supported Card Sizes
 
-| Size              | Dimensions  | Common Games                                                    |
-| ----------------- | ----------- | --------------------------------------------------------------- |
-| `standard`        | 63x88mm     | MTG, Pokemon, Lorcana, One Piece, Digimon, Star Wars: Unlimited |
-| `standard_double` | 126x88mm    | MTG oversized (Planechase, Archenemy, Commander)                |
-| `japanese`        | 59x86mm     | Yu-Gi-Oh!                                                       |
-| `poker`           | 2.5x3.5in   | Standard playing cards                                          |
-| `bridge`          | 2.25x3.5in  | Bridge cards                                                    |
-| `tarot`           | 2.75x4.75in | Tarot cards                                                     |
+| Size | Dimensions | Common Games |
+|------|-----------|--------------|
+| `standard` | 63x88mm | MTG, Pokemon, Lorcana, One Piece, Digimon, Star Wars: Unlimited |
+| `standard_double` | 126x88mm | MTG oversized (Planechase, Archenemy, Commander) |
+| `japanese` | 59x86mm | Yu-Gi-Oh! |
+| `poker` | 2.5x3.5in | Standard playing cards |
+| `bridge` | 2.25x3.5in | Bridge cards |
+| `tarot` | 2.75x4.75in | Tarot cards |
 
 ## Code Style Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ plugins/<game>/
 
 Plugins read decklists and download card images to `game/front/` (and `game/double_sided/` for double-faced cards).
 
-Supported games include: MTG, Yu-Gi-Oh!, Pokemon, Lorcana, Digimon, One Piece, Flesh and Blood, Star Wars: Unlimited, Grand Archive, Gundam, Netrunner, KeyForge, Altered, Ashes Reborn, Elestrals, and Riftbound.
+Supported games include: Altered, Ashes Reborn, Bushiroad, Digimon, Echoes of Astra, Elestrals, Final Fantasy, Flesh and Blood, Grand Archive, Gundam, KeyForge, Lorcana, MTG, Netrunner, One Piece, Pokemon, Riftbound, Sorcery: Contested Realm, Star Wars: Unlimited, and Yu-Gi-Oh!
 
 ## Development Setup
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This file provides context for AI coding assistants working on this project.
 **Silhouette Card Maker** is a collection of tools and cutting templates for utilizing Silhouette cutting machines to cut cards. Users can create DIY card games or proxies for various trading card games (TCGs).
 
 The project consists of:
+
 - Python scripts for PDF generation and offset calibration
 - Silhouette Studio cutting templates
 - Plugins for fetching card images from various TCG databases
@@ -51,11 +52,11 @@ silhouette-card-maker/
 
 When documentation changes are made, similar changes need to be made in both locations:
 
-| README.md Section | Hugo Content Location |
-|-------------------|----------------------|
-| Root README.md | `hugo/content/_index.md` |
-| `create_pdf.py` docs | `hugo/content/docs/create.md` |
-| `offset_pdf.py` docs | `hugo/content/docs/offset.md` |
+| README.md Section          | Hugo Content Location            |
+| -------------------------- | -------------------------------- |
+| Root README.md             | `hugo/content/_index.md`         |
+| `create_pdf.py` docs       | `hugo/content/docs/create.md`    |
+| `offset_pdf.py` docs       | `hugo/content/docs/offset.md`    |
 | `plugins/<game>/README.md` | `hugo/content/plugins/<game>.md` |
 
 The Hugo site is deployed to: https://alan-cha.github.io/silhouette-card-maker
@@ -66,41 +67,43 @@ The Hugo site is deployed to: https://alan-cha.github.io/silhouette-card-maker
 
 Run by end users as part of the normal card-making workflow.
 
-| Script | Purpose |
-|--------|---------|
-| `create_pdf.py` | Lay out card images into a print-ready PDF with registration marks |
+| Script          | Purpose                                                                         |
+| --------------- | ------------------------------------------------------------------------------- |
+| `create_pdf.py` | Lay out card images into a print-ready PDF with registration marks              |
 | `offset_pdf.py` | Add x/y/angle offset to a PDF to compensate for printer front/back misalignment |
-| `clean_up.py` | Delete all images from `game/front/` and `game/double_sided/` to start fresh |
+| `clean_up.py`   | Delete all images from `game/front/` and `game/double_sided/` to start fresh    |
 
 ### Developer/maintainer tools
 
 Run by maintainers to regenerate project artifacts. Not needed for normal card-making use.
 
-| Script | Purpose |
-|--------|---------|
-| `generate_calibration.py` | Generate calibration PDFs for all paper sizes |
-| `generate_dxf.py` | Generate DXF cutting templates from `assets/layouts.json` |
-| `dxf_to_studio3.py` | Convert DXF files to Silhouette Studio `.studio3` format; subcommands: `convert` (single file), `batch` (all DXFs), `calibrate` (record UI coordinates) |
-| `generate_readme_tables.py` | Regenerate the card/paper size tables in `README.md` and Hugo docs |
+| Script                      | Purpose                                                                                                                                                 |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `generate_calibration.py`   | Generate calibration PDFs for all paper sizes                                                                                                           |
+| `generate_dxf.py`           | Generate DXF cutting templates from `assets/layouts.json`                                                                                               |
+| `dxf_to_studio3.py`         | Convert DXF files to Silhouette Studio `.studio3` format; subcommands: `convert` (single file), `batch` (all DXFs), `calibrate` (record UI coordinates) |
+| `generate_readme_tables.py` | Regenerate the card/paper size tables in `README.md` and Hugo docs                                                                                      |
 
 ### Internal modules
 
 Imported by other scripts. Not intended to be run directly.
 
-| Module | Purpose |
-|--------|---------|
-| `utilities.py` | Shared data loading: `LayoutConfig`, `load_layout_config`, `template_name`, etc. |
-| `enums.py` | Shared enums: `Orientation` |
-| `size_convert.py` | Unit conversion utilities (pixels, mm, inches) |
-| `page_manager.py` | Card layout and page geometry calculations |
-| `dxf_manager.py` | DXF file generation utilities |
+| Module            | Purpose                                                                          |
+| ----------------- | -------------------------------------------------------------------------------- |
+| `utilities.py`    | Shared data loading: `LayoutConfig`, `load_layout_config`, `template_name`, etc. |
+| `enums.py`        | Shared enums: `Orientation`                                                      |
+| `size_convert.py` | Unit conversion utilities (pixels, mm, inches)                                   |
+| `page_manager.py` | Card layout and page geometry calculations                                       |
+| `dxf_manager.py`  | DXF file generation utilities                                                    |
 
 ### Key Script Details
 
 #### create_pdf.py
+
 Creates PDFs with card layouts and registration marks for cutting. Supports multiple card sizes (standard, japanese, poker, bridge, tarot, etc.) and paper sizes (letter, tabloid, a4, a3, arch_b).
 
 Key options:
+
 - `--card_size` / `--paper_size`: Card and paper dimensions
 - `--extend_corners`: Fix artifacts from rounded corner images
 - `--crop`: Crop existing print bleed from images
@@ -108,9 +111,11 @@ Key options:
 - `--skip`: Skip cards near registration marks
 
 #### offset_pdf.py
+
 Adds offset to every other page in a PDF to compensate for printer front/back misalignment. Supports x/y offset and angle rotation.
 
 Key options:
+
 - `--x_offset` / `--y_offset`: Pixel offset values
 - `--angle`: Rotational offset in degrees
 - `--save`: Persist offset values for future use
@@ -129,7 +134,7 @@ plugins/<game>/
 
 Plugins read decklists and download card images to `game/front/` (and `game/double_sided/` for double-faced cards).
 
-Supported games include: MTG, Yu-Gi-Oh!, Pokemon, Lorcana, Digimon, One Piece, Flesh and Blood, Star Wars: Unlimited, Grand Archive, Gundam, Netrunner, Altered, Ashes Reborn, Elestrals, and Riftbound.
+Supported games include: MTG, Yu-Gi-Oh!, Pokemon, Lorcana, Digimon, One Piece, Flesh and Blood, Star Wars: Unlimited, Grand Archive, Gundam, KeyForge, Netrunner, Altered, Ashes Reborn, Elestrals, and Riftbound.
 
 ## Development Setup
 
@@ -160,14 +165,14 @@ The theme is included as a git submodule in `hugo/themes/hextra/`.
 
 ## Supported Card Sizes
 
-| Size | Dimensions | Common Games |
-|------|-----------|--------------|
-| `standard` | 63x88mm | MTG, Pokemon, Lorcana, One Piece, Digimon, Star Wars: Unlimited |
-| `standard_double` | 126x88mm | MTG oversized (Planechase, Archenemy, Commander) |
-| `japanese` | 59x86mm | Yu-Gi-Oh! |
-| `poker` | 2.5x3.5in | Standard playing cards |
-| `bridge` | 2.25x3.5in | Bridge cards |
-| `tarot` | 2.75x4.75in | Tarot cards |
+| Size              | Dimensions  | Common Games                                                    |
+| ----------------- | ----------- | --------------------------------------------------------------- |
+| `standard`        | 63x88mm     | MTG, Pokemon, Lorcana, One Piece, Digimon, Star Wars: Unlimited |
+| `standard_double` | 126x88mm    | MTG oversized (Planechase, Archenemy, Commander)                |
+| `japanese`        | 59x86mm     | Yu-Gi-Oh!                                                       |
+| `poker`           | 2.5x3.5in   | Standard playing cards                                          |
+| `bridge`          | 2.25x3.5in  | Bridge cards                                                    |
+| `tarot`           | 2.75x4.75in | Tarot cards                                                     |
 
 ## Code Style Notes
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ The [Grand Archive plugin](plugins/grand_archive/README.md) supports **Omnideck*
 
 The [Gundam plugin](plugins/gundam/README.md) supports **DeckPlanet**, **Egman Events**, **ExBurst**, and **Limitless TCG** formats.
 
+The [KeyForge plugin](plugins/keyforge/README.md) supports **Master Vault** (including **Decks of KeyForge** links) and **Archon Arcana** formats.
+
 The [Lord of the Rings: Living Card Game plugin](plugins/lotr_lcg/README.md) supports **RingsDB decklists**, **RingsDB fellowships**, and **RingsDB scenarios**, using user-supplied local back scans.
 
 The [Lorcana plugin](plugins/lorcana/README.md) supports **Dreamborn** format.

--- a/hugo/content/plugins/keyforge.md
+++ b/hugo/content/plugins/keyforge.md
@@ -15,12 +15,12 @@ If you're on macOS or Linux, open **Terminal**. If you're on Windows, open **Pow
 
 Create and start your virtual Python environment and install Python dependencies if you have not done so already. See [here]({{% ref "../docs/create/#basic-usage" %}}) for more information.
 
-Put your decklist into a text file in `game/decklist`. In this example, the filename is `deck.txt` and the decklist format is Master Vault (`master_vault`).
+Put your decklist into a text file in `game/decklist`. In this example, the filename is `deck.txt` and the decklist format is Master Vault (`master_vault_url`).
 
 Run the script.
 
 ```sh
-python plugins/keyforge/fetch.py game/decklist/deck.txt master_vault
+python plugins/keyforge/fetch.py game/decklist/deck.txt master_vault_url
 ```
 
 Card images are always downloaded from Archon Arcana because it hosts higher-resolution art than Master Vault. Any cards that could not be found are reported together at the end.
@@ -34,35 +34,46 @@ Now you can create the PDF using [`create_pdf.py`]({{% ref "../docs/create" %}})
 python create_pdf.py
 ```
 
-> [!NOTE]
-> The Archon Arcana art is not exactly the `standard` card aspect ratio, so the default `stretch` fit distorts it very slightly. To preserve the aspect ratio instead (trimming a negligible sliver), add `--fit crop`.
->
-> ```sh
-> python create_pdf.py --fit crop
-> ```
-
 > [!TIP]
 > KeyForge cards share a common card back, which you provide in `game/back/`. Blank card backs are available in the [keyteki repository](https://github.com/keyteki/keyteki/tree/master/client/assets/img/idbacks/idback_blanks).
 
 ## CLI Options
 
 ```
-Usage: fetch.py [OPTIONS] DECK_PATH {archon_arcana|master_vault}
+Usage: fetch.py [OPTIONS] DECK_PATH {archon_arcana|master_vault_url|decks_of_keyforge_url}
 
 Options:
   --help  Show this message and exit.
 ```
 
+### Examples
+
+You can also use a deck URL directly in the command line instead of saving it to a file first. Note the single quotes around the URL.
+
+```sh
+python plugins/keyforge/fetch.py 'https://www.keyforgegame.com/deck-details/4b86855f-71e5-4f54-a20d-2a58ec973f9c' master_vault_url
+python plugins/keyforge/fetch.py 'https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a' decks_of_keyforge_url
+```
+
 ## Formats
 
-### `master_vault`
+### `master_vault_url`
 
-A [Master Vault](https://www.keyforgegame.com) or [Decks of KeyForge](https://decksofkeyforge.com) deck URL. Decks of KeyForge uses the same deck ID as Master Vault, so both are resolved through Master Vault. The plugin reads the full deck, including non-deck cards such as Prophecies, and downloads each card's art from Archon Arcana.
+A [Master Vault](https://www.keyforgegame.com) deck URL. The plugin reads the full deck, including non-deck cards such as Prophecies, and downloads each card's art from Archon Arcana.
 
-List one deck URL per line. You can mix Master Vault and Decks of KeyForge URLs to combine several decks into a single PDF.
+List one deck URL per line to combine several decks into a single PDF.
 
 ```
 https://www.keyforgegame.com/deck-details/4b86855f-71e5-4f54-a20d-2a58ec973f9c
+```
+
+### `decks_of_keyforge_url`
+
+A [Decks of KeyForge](https://decksofkeyforge.com) deck URL. Decks of KeyForge uses the same deck ID as Master Vault, so the deck is read the same way, including non-deck cards such as Prophecies, with each card's art downloaded from Archon Arcana.
+
+List one deck URL per line to combine several decks into a single PDF.
+
+```
 https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a
 ```
 

--- a/hugo/content/plugins/keyforge.md
+++ b/hugo/content/plugins/keyforge.md
@@ -46,15 +46,6 @@ Options:
   --help  Show this message and exit.
 ```
 
-### Examples
-
-You can also use a deck URL directly in the command line instead of saving it to a file first. Note the single quotes around the URL.
-
-```sh
-python plugins/keyforge/fetch.py 'https://www.keyforgegame.com/deck-details/4b86855f-71e5-4f54-a20d-2a58ec973f9c' master_vault_url
-python plugins/keyforge/fetch.py 'https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a' decks_of_keyforge_url
-```
-
 ## Formats
 
 ### `master_vault_url`
@@ -67,6 +58,12 @@ List one deck URL per line to combine several decks into a single PDF.
 https://www.keyforgegame.com/deck-details/4b86855f-71e5-4f54-a20d-2a58ec973f9c
 ```
 
+You can also use a Master Vault URL directly in the command line.
+
+```sh
+python plugins/keyforge/fetch.py https://www.keyforgegame.com/deck-details/4b86855f-71e5-4f54-a20d-2a58ec973f9c master_vault_url
+```
+
 ### `decks_of_keyforge_url`
 
 A [Decks of KeyForge](https://decksofkeyforge.com) deck URL. Decks of KeyForge uses the same deck ID as Master Vault, so the deck is read the same way, including non-deck cards such as Prophecies, with each card's art downloaded from Archon Arcana.
@@ -75,6 +72,12 @@ List one deck URL per line to combine several decks into a single PDF.
 
 ```
 https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a
+```
+
+You can also use a Decks of KeyForge URL directly in the command line.
+
+```sh
+python plugins/keyforge/fetch.py https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a decks_of_keyforge_url
 ```
 
 ### `archon_arcana`

--- a/hugo/content/plugins/keyforge.md
+++ b/hugo/content/plugins/keyforge.md
@@ -50,9 +50,7 @@ Options:
 
 ### `master_vault_url`
 
-A [Master Vault](https://www.keyforgegame.com) deck URL. The plugin reads the full deck, including non-deck cards such as Prophecies, and downloads each card's art from Archon Arcana.
-
-List one deck URL per line to combine several decks into a single PDF.
+Master Vault deck URL format.
 
 ```
 https://www.keyforgegame.com/deck-details/4b86855f-71e5-4f54-a20d-2a58ec973f9c
@@ -66,9 +64,7 @@ python plugins/keyforge/fetch.py https://www.keyforgegame.com/deck-details/4b868
 
 ### `decks_of_keyforge_url`
 
-A [Decks of KeyForge](https://decksofkeyforge.com) deck URL. Decks of KeyForge uses the same deck ID as Master Vault, so the deck is read the same way, including non-deck cards such as Prophecies, with each card's art downloaded from Archon Arcana.
-
-List one deck URL per line to combine several decks into a single PDF.
+Decks of KeyForge deck URL format.
 
 ```
 https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a

--- a/hugo/content/plugins/keyforge.md
+++ b/hugo/content/plugins/keyforge.md
@@ -1,0 +1,80 @@
+---
+title: 'KeyForge'
+weight: 65
+---
+
+This plugin reads a decklist, fetches the card images from the [Archon Arcana](https://www.archonarcana.com) wiki, and puts the card images into the proper `game/` directories.
+
+This plugin supports decklist URLs from [Master Vault](https://www.keyforgegame.com) and [Decks of KeyForge](https://decksofkeyforge.com), as well as a plain list of cards. To learn more, see [here](#formats).
+
+## Basic Instructions
+
+Navigate to the root directory as plugins are not meant to be run in the plugins directory.
+
+If you're on macOS or Linux, open **Terminal**. If you're on Windows, open **PowerShell**.
+
+Create and start your virtual Python environment and install Python dependencies if you have not done so already. See [here]({{% ref "../docs/create/#basic-usage" %}}) for more information.
+
+Put your decklist into a text file in `game/decklist`. In this example, the filename is `deck.txt` and the decklist format is Master Vault (`master_vault`).
+
+Run the script.
+
+```sh
+python plugins/keyforge/fetch.py game/decklist/deck.txt master_vault
+```
+
+Card images are always downloaded from Archon Arcana because it hosts higher-resolution art than Master Vault. Any cards that could not be found are reported together at the end.
+
+> [!NOTE]
+> Card enhancements (the æmber, capture, damage, and draw pips added to specific cards in a deck) are not currently handled, so enhanced cards are printed with their standard, unenhanced art.
+
+Now you can create the PDF using [`create_pdf.py`]({{% ref "../docs/create" %}}). KeyForge uses the `standard` card size, which is the default.
+
+```sh
+python create_pdf.py
+```
+
+> [!NOTE]
+> The Archon Arcana art is not exactly the `standard` card aspect ratio, so the default `stretch` fit distorts it very slightly. To preserve the aspect ratio instead (trimming a negligible sliver), add `--fit crop`.
+>
+> ```sh
+> python create_pdf.py --fit crop
+> ```
+
+> [!TIP]
+> KeyForge cards share a common card back, which you provide in `game/back/`. Blank card backs are available in the [keyteki repository](https://github.com/keyteki/keyteki/tree/master/client/assets/img/idbacks/idback_blanks).
+
+## CLI Options
+
+```
+Usage: fetch.py [OPTIONS] DECK_PATH {archon_arcana|master_vault}
+
+Options:
+  --help  Show this message and exit.
+```
+
+## Formats
+
+### `master_vault`
+
+A [Master Vault](https://www.keyforgegame.com) or [Decks of KeyForge](https://decksofkeyforge.com) deck URL. Decks of KeyForge uses the same deck ID as Master Vault, so both are resolved through Master Vault. The plugin reads the full deck, including non-deck cards such as Prophecies, and downloads each card's art from Archon Arcana.
+
+List one deck URL per line. You can mix Master Vault and Decks of KeyForge URLs to combine several decks into a single PDF.
+
+```
+https://www.keyforgegame.com/deck-details/4b86855f-71e5-4f54-a20d-2a58ec973f9c
+https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a
+```
+
+### `archon_arcana`
+
+A plain list of cards, one per line. Each card can be referenced as an Archon Arcana URL or a card name. Names are matched case-insensitively, and spaces and underscores are interchangeable, so all of the following refer to the same card:
+
+```
+https://www.archonarcana.com/wiki/Gracchan_Reform
+Gracchan_Reform
+Gracchan Reform
+gracchan reform
+```
+
+Special characters can be written in plain ASCII: `AEmber Imp`, `Nature's Call`, and `Shae "Cloudkicker"` resolve to their `Æmber`, curly-apostrophe, and curly-quote spellings on Archon Arcana. Accents can be omitted too (for example, `Gezdrutyo the Arcane`), and if there is no exact match, the closest Archon Arcana search result is used as a last resort.

--- a/hugo/content/plugins/keyforge.md
+++ b/hugo/content/plugins/keyforge.md
@@ -67,13 +67,13 @@ python plugins/keyforge/fetch.py https://www.keyforgegame.com/deck-details/4b868
 Decks of KeyForge deck URL format.
 
 ```
-https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a
+https://decksofkeyforge.com/decks/4b86855f-71e5-4f54-a20d-2a58ec973f9c
 ```
 
 You can also use a Decks of KeyForge URL directly in the command line.
 
 ```sh
-python plugins/keyforge/fetch.py https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a decks_of_keyforge_url
+python plugins/keyforge/fetch.py https://decksofkeyforge.com/decks/4b86855f-71e5-4f54-a20d-2a58ec973f9c decks_of_keyforge_url
 ```
 
 ### `archon_arcana`

--- a/plugins/keyforge/README.md
+++ b/plugins/keyforge/README.md
@@ -1,0 +1,77 @@
+# KeyForge Plugin
+
+This plugin reads a decklist, fetches the card images from the [Archon Arcana](https://www.archonarcana.com) wiki, and puts the card images into the proper `game/` directories.
+
+This plugin supports decklist URLs from [Master Vault](https://www.keyforgegame.com) and [Decks of KeyForge](https://decksofkeyforge.com), as well as a plain list of cards. To learn more, see [here](#formats).
+
+## Basic Instructions
+
+Navigate to the [root directory](../..) as plugins are not meant to be run in the [plugin directory](.).
+
+If you're on macOS or Linux, open **Terminal**. If you're on Windows, open **PowerShell**.
+
+Create and start your virtual Python environment and install Python dependencies if you have not done so already. See [here](../../README.md#basic-usage) for more information.
+
+Put your decklist into a text file in [game/decklist](../game/decklist/). In this example, the filename is `deck.txt` and the decklist format is Master Vault (`master_vault`).
+
+Run the script.
+
+```sh
+python plugins/keyforge/fetch.py game/decklist/deck.txt master_vault
+```
+
+Card images are always downloaded from Archon Arcana because it hosts higher-resolution art than Master Vault. Any cards that could not be found are reported together at the end.
+
+> [!NOTE]
+> Card enhancements (the æmber, capture, damage, and draw pips added to specific cards in a deck) are not currently handled, so enhanced cards are printed with their standard, unenhanced art.
+
+Now you can create the PDF using [`create_pdf.py`](../../README.md#create_pdfpy). KeyForge uses the `standard` card size, which is the default.
+
+```sh
+python create_pdf.py
+```
+
+> [!NOTE]
+> The Archon Arcana art is not exactly the `standard` card aspect ratio, so the default `stretch` fit distorts it very slightly. To preserve the aspect ratio instead (trimming a negligible sliver), add `--fit crop`.
+>
+> ```sh
+> python create_pdf.py --fit crop
+> ```
+
+> [!TIP]
+> KeyForge cards share a common card back, which you provide in `game/back/`. Blank card backs are available in the [keyteki repository](https://github.com/keyteki/keyteki/tree/master/client/assets/img/idbacks/idback_blanks).
+
+## CLI Options
+
+```
+Usage: fetch.py [OPTIONS] DECK_PATH {archon_arcana|master_vault}
+
+Options:
+  --help  Show this message and exit.
+```
+
+## Formats
+
+### `master_vault`
+
+A [Master Vault](https://www.keyforgegame.com) or [Decks of KeyForge](https://decksofkeyforge.com) deck URL. Decks of KeyForge uses the same deck ID as Master Vault, so both are resolved through Master Vault. The plugin reads the full deck, including non-deck cards such as Prophecies, and downloads each card's art from Archon Arcana.
+
+List one deck URL per line. You can mix Master Vault and Decks of KeyForge URLs to combine several decks into a single PDF.
+
+```
+https://www.keyforgegame.com/deck-details/4b86855f-71e5-4f54-a20d-2a58ec973f9c
+https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a
+```
+
+### `archon_arcana`
+
+A plain list of cards, one per line. Each card can be referenced as an Archon Arcana URL or a card name. Names are matched case-insensitively, and spaces and underscores are interchangeable, so all of the following refer to the same card:
+
+```
+https://www.archonarcana.com/wiki/Gracchan_Reform
+Gracchan_Reform
+Gracchan Reform
+gracchan reform
+```
+
+Special characters can be written in plain ASCII: `AEmber Imp`, `Nature's Call`, and `Shae "Cloudkicker"` resolve to their `Æmber`, curly-apostrophe, and curly-quote spellings on Archon Arcana. Accents can be omitted too (for example, `Gezdrutyo the Arcane`), and if there is no exact match, the closest Archon Arcana search result is used as a last resort.

--- a/plugins/keyforge/README.md
+++ b/plugins/keyforge/README.md
@@ -43,15 +43,6 @@ Options:
   --help  Show this message and exit.
 ```
 
-### Examples
-
-You can also use a deck URL directly in the command line instead of saving it to a file first. Note the single quotes around the URL.
-
-```sh
-python plugins/keyforge/fetch.py 'https://www.keyforgegame.com/deck-details/4b86855f-71e5-4f54-a20d-2a58ec973f9c' master_vault_url
-python plugins/keyforge/fetch.py 'https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a' decks_of_keyforge_url
-```
-
 ## Formats
 
 ### `master_vault_url`
@@ -64,6 +55,12 @@ List one deck URL per line to combine several decks into a single PDF.
 https://www.keyforgegame.com/deck-details/4b86855f-71e5-4f54-a20d-2a58ec973f9c
 ```
 
+You can also use a Master Vault URL directly in the command line.
+
+```sh
+python plugins/keyforge/fetch.py https://www.keyforgegame.com/deck-details/4b86855f-71e5-4f54-a20d-2a58ec973f9c master_vault_url
+```
+
 ### `decks_of_keyforge_url`
 
 A [Decks of KeyForge](https://decksofkeyforge.com) deck URL. Decks of KeyForge uses the same deck ID as Master Vault, so the deck is read the same way, including non-deck cards such as Prophecies, with each card's art downloaded from Archon Arcana.
@@ -72,6 +69,12 @@ List one deck URL per line to combine several decks into a single PDF.
 
 ```
 https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a
+```
+
+You can also use a Decks of KeyForge URL directly in the command line.
+
+```sh
+python plugins/keyforge/fetch.py https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a decks_of_keyforge_url
 ```
 
 ### `archon_arcana`

--- a/plugins/keyforge/README.md
+++ b/plugins/keyforge/README.md
@@ -12,12 +12,12 @@ If you're on macOS or Linux, open **Terminal**. If you're on Windows, open **Pow
 
 Create and start your virtual Python environment and install Python dependencies if you have not done so already. See [here](../../README.md#basic-usage) for more information.
 
-Put your decklist into a text file in [game/decklist](../game/decklist/). In this example, the filename is `deck.txt` and the decklist format is Master Vault (`master_vault`).
+Put your decklist into a text file in [game/decklist](../game/decklist/). In this example, the filename is `deck.txt` and the decklist format is Master Vault (`master_vault_url`).
 
 Run the script.
 
 ```sh
-python plugins/keyforge/fetch.py game/decklist/deck.txt master_vault
+python plugins/keyforge/fetch.py game/decklist/deck.txt master_vault_url
 ```
 
 Card images are always downloaded from Archon Arcana because it hosts higher-resolution art than Master Vault. Any cards that could not be found are reported together at the end.
@@ -31,35 +31,46 @@ Now you can create the PDF using [`create_pdf.py`](../../README.md#create_pdfpy)
 python create_pdf.py
 ```
 
-> [!NOTE]
-> The Archon Arcana art is not exactly the `standard` card aspect ratio, so the default `stretch` fit distorts it very slightly. To preserve the aspect ratio instead (trimming a negligible sliver), add `--fit crop`.
->
-> ```sh
-> python create_pdf.py --fit crop
-> ```
-
 > [!TIP]
 > KeyForge cards share a common card back, which you provide in `game/back/`. Blank card backs are available in the [keyteki repository](https://github.com/keyteki/keyteki/tree/master/client/assets/img/idbacks/idback_blanks).
 
 ## CLI Options
 
 ```
-Usage: fetch.py [OPTIONS] DECK_PATH {archon_arcana|master_vault}
+Usage: fetch.py [OPTIONS] DECK_PATH {archon_arcana|master_vault_url|decks_of_keyforge_url}
 
 Options:
   --help  Show this message and exit.
 ```
 
+### Examples
+
+You can also use a deck URL directly in the command line instead of saving it to a file first. Note the single quotes around the URL.
+
+```sh
+python plugins/keyforge/fetch.py 'https://www.keyforgegame.com/deck-details/4b86855f-71e5-4f54-a20d-2a58ec973f9c' master_vault_url
+python plugins/keyforge/fetch.py 'https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a' decks_of_keyforge_url
+```
+
 ## Formats
 
-### `master_vault`
+### `master_vault_url`
 
-A [Master Vault](https://www.keyforgegame.com) or [Decks of KeyForge](https://decksofkeyforge.com) deck URL. Decks of KeyForge uses the same deck ID as Master Vault, so both are resolved through Master Vault. The plugin reads the full deck, including non-deck cards such as Prophecies, and downloads each card's art from Archon Arcana.
+A [Master Vault](https://www.keyforgegame.com) deck URL. The plugin reads the full deck, including non-deck cards such as Prophecies, and downloads each card's art from Archon Arcana.
 
-List one deck URL per line. You can mix Master Vault and Decks of KeyForge URLs to combine several decks into a single PDF.
+List one deck URL per line to combine several decks into a single PDF.
 
 ```
 https://www.keyforgegame.com/deck-details/4b86855f-71e5-4f54-a20d-2a58ec973f9c
+```
+
+### `decks_of_keyforge_url`
+
+A [Decks of KeyForge](https://decksofkeyforge.com) deck URL. Decks of KeyForge uses the same deck ID as Master Vault, so the deck is read the same way, including non-deck cards such as Prophecies, with each card's art downloaded from Archon Arcana.
+
+List one deck URL per line to combine several decks into a single PDF.
+
+```
 https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a
 ```
 

--- a/plugins/keyforge/README.md
+++ b/plugins/keyforge/README.md
@@ -47,9 +47,7 @@ Options:
 
 ### `master_vault_url`
 
-A [Master Vault](https://www.keyforgegame.com) deck URL. The plugin reads the full deck, including non-deck cards such as Prophecies, and downloads each card's art from Archon Arcana.
-
-List one deck URL per line to combine several decks into a single PDF.
+Master Vault deck URL format.
 
 ```
 https://www.keyforgegame.com/deck-details/4b86855f-71e5-4f54-a20d-2a58ec973f9c
@@ -63,9 +61,7 @@ python plugins/keyforge/fetch.py https://www.keyforgegame.com/deck-details/4b868
 
 ### `decks_of_keyforge_url`
 
-A [Decks of KeyForge](https://decksofkeyforge.com) deck URL. Decks of KeyForge uses the same deck ID as Master Vault, so the deck is read the same way, including non-deck cards such as Prophecies, with each card's art downloaded from Archon Arcana.
-
-List one deck URL per line to combine several decks into a single PDF.
+Decks of KeyForge deck URL format.
 
 ```
 https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a

--- a/plugins/keyforge/README.md
+++ b/plugins/keyforge/README.md
@@ -64,13 +64,13 @@ python plugins/keyforge/fetch.py https://www.keyforgegame.com/deck-details/4b868
 Decks of KeyForge deck URL format.
 
 ```
-https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a
+https://decksofkeyforge.com/decks/4b86855f-71e5-4f54-a20d-2a58ec973f9c
 ```
 
 You can also use a Decks of KeyForge URL directly in the command line.
 
 ```sh
-python plugins/keyforge/fetch.py https://decksofkeyforge.com/decks/79c716d4-9605-4c8d-8b4c-5f9c9d3e2b7a decks_of_keyforge_url
+python plugins/keyforge/fetch.py https://decksofkeyforge.com/decks/4b86855f-71e5-4f54-a20d-2a58ec973f9c decks_of_keyforge_url
 ```
 
 ### `archon_arcana`

--- a/plugins/keyforge/archonarcana.py
+++ b/plugins/keyforge/archonarcana.py
@@ -21,7 +21,8 @@ RATE_LIMIT_SECONDS = 0.075
 FUZZY_MATCH_THRESHOLD = 0.8
 
 URL_PATTERN = compile(r'^https?://', IGNORECASE)
-WIKI_PATH_PATTERN = compile(r'/wiki/(.+)$')
+# Stop at '?' or '#' so a pasted URL's query string or fragment isn't swept into the title.
+WIKI_PATH_PATTERN = compile(r'/wiki/([^?#]+)')
 
 # Archon Arcana page titles use typographic characters. Map common ASCII input to them,
 # e.g. AEmber Imp -> Æmber Imp, Nature's Call -> Nature’s Call, Shae "Cloudkicker" -> Shae “Cloudkicker”.
@@ -124,8 +125,10 @@ def resolve_card(entry: str) -> Tuple[str, str]:
     if result is None:
         # Exact title not found. Retry via search to handle casing and space/underscore differences.
         resolved = search_title(title)
-        if resolved is not None:
+        if resolved is not None and resolved != title:
             result = query_page_image(resolved)
+        if resolved is not None:
+            title = resolved
 
     if result is None:
         raise Exception(f'card not found on Archon Arcana: "{title}"')

--- a/plugins/keyforge/archonarcana.py
+++ b/plugins/keyforge/archonarcana.py
@@ -1,4 +1,5 @@
 from difflib import SequenceMatcher
+from functools import partial
 from html import unescape
 from os import path
 from re import IGNORECASE, compile, sub
@@ -55,7 +56,7 @@ def remove_nonalphanumeric(s: str) -> str:
 
 def normalize_title(title: str) -> str:
     # MediaWiki treats spaces and underscores as equivalent and is case-insensitive on the first letter.
-    normalized = sub(r'\s+', ' ', title.replace('_', ' ')).strip().lower()
+    normalized = sub(r'[\s_]+', ' ', title).strip().lower()
     # Strip accents (Gĕzdrutyŏ -> gezdrutyo) and fold typographic variants so spellings compare equal.
     normalized = ''.join(c for c in normalize_unicode('NFKD', normalized) if not combining(c))
     return normalized.translate(TYPOGRAPHIC_TRANSLATION).replace('\u00e6', 'ae')
@@ -119,19 +120,17 @@ def extract_image_url(html: str) -> Optional[str]:
 
 def resolve_card(entry: str) -> Tuple[str, str]:
     title = translate_special_characters(entry_to_title(entry))
-
     response = request_archonarcana(title_to_url(title), allow_missing=True)
 
     if response is None:
         # Exact title not found. Retry via search to handle casing and space/underscore differences.
         resolved = search_title(title)
-        if resolved is None:
-            raise Exception(f'card not found on Archon Arcana: "{title}"')
+        if resolved is not None:
+            title = resolved
+            response = request_archonarcana(title_to_url(title), allow_missing=True)
 
-        title = resolved
-        response = request_archonarcana(title_to_url(title), allow_missing=True)
-        if response is None:
-            raise Exception(f'card not found on Archon Arcana: "{title}"')
+    if response is None:
+        raise Exception(f'card not found on Archon Arcana: "{title}"')
 
     image_url = extract_image_url(response.text)
     if image_url is None:
@@ -151,15 +150,5 @@ def fetch_card_art(index: int, card_name: str, quantity: int, front_img_dir: str
         with open(image_path, 'wb') as f:
             f.write(card_art)
 
-def get_handle_card(
-    front_img_dir: str
-):
-    def configured_fetch_card(index: int, card_name: str, quantity: int = 1):
-        fetch_card_art(
-            index,
-            card_name,
-            quantity,
-            front_img_dir
-        )
-
-    return configured_fetch_card
+def get_handle_card(front_img_dir: str):
+    return partial(fetch_card_art, front_img_dir=front_img_dir)

--- a/plugins/keyforge/archonarcana.py
+++ b/plugins/keyforge/archonarcana.py
@@ -1,0 +1,165 @@
+from difflib import SequenceMatcher
+from html import unescape
+from os import path
+from re import IGNORECASE, compile, sub
+from time import sleep
+from typing import Optional, Tuple
+from unicodedata import combining
+from unicodedata import normalize as normalize_unicode
+from urllib.parse import quote, unquote
+
+from requests import Response, Session
+
+session = Session()
+
+USER_AGENT = 'silhouette-card-maker/0.1'
+WIKI_PAGE_TEMPLATE = 'https://www.archonarcana.com/wiki/{title}'
+API_URL = 'https://www.archonarcana.com/w139/api.php'
+
+RATE_LIMIT_SECONDS = 0.075
+
+# Minimum similarity for the last-resort fuzzy match to accept a search result.
+FUZZY_MATCH_THRESHOLD = 0.8
+
+# The card art is the single MediaWiki "image" anchor on a card page.
+IMAGE_ANCHOR_PATTERN = compile(r'<a[^>]*class="image"[^>]*>\s*<img[^>]*\bsrc="([^"]+)"', IGNORECASE)
+# MediaWiki thumbnails look like `.../thumb/<file>/<width>px-<file>`; the original drops the thumb segment.
+THUMB_PATTERN = compile(r'/thumb/(.+)/[^/]+$')
+URL_PATTERN = compile(r'^https?://', IGNORECASE)
+WIKI_PATH_PATTERN = compile(r'/wiki/(.+)$')
+
+# Archon Arcana page titles use typographic characters. Map common ASCII input to them,
+# e.g. AEmber Imp -> Æmber Imp, Nature's Call -> Nature’s Call, Shae "Cloudkicker" -> Shae “Cloudkicker”.
+LIGATURE_PATTERN = compile(r'AE(?=[a-z])')
+DOUBLE_QUOTE_PATTERN = compile(r'"([^"]*)"')
+ASCII_APOSTROPHE_TRANSLATION = str.maketrans({"'": '\u2019'})
+# Fold those typographic characters back to ASCII so different spellings compare equal.
+TYPOGRAPHIC_TRANSLATION = str.maketrans({'\u2019': "'", '\u201c': '"', '\u201d': '"'})
+
+def request_archonarcana(url: str, params: Optional[dict] = None, allow_missing: bool = False) -> Optional[Response]:
+    r = session.get(url, params=params, headers={'user-agent': USER_AGENT, 'accept': '*/*'})
+
+    sleep(RATE_LIMIT_SECONDS)
+
+    # A missing wiki page responds with 404. Let callers treat that as "does not exist".
+    if allow_missing and r.status_code == 404:
+        return None
+
+    # Check for 2XX response code
+    r.raise_for_status()
+
+    return r
+
+def remove_nonalphanumeric(s: str) -> str:
+    return sub(r'[^\w]', '', s)
+
+def normalize_title(title: str) -> str:
+    # MediaWiki treats spaces and underscores as equivalent and is case-insensitive on the first letter.
+    normalized = sub(r'\s+', ' ', title.replace('_', ' ')).strip().lower()
+    # Strip accents (Gĕzdrutyŏ -> gezdrutyo) and fold typographic variants so spellings compare equal.
+    normalized = ''.join(c for c in normalize_unicode('NFKD', normalized) if not combining(c))
+    return normalized.translate(TYPOGRAPHIC_TRANSLATION).replace('\u00e6', 'ae')
+
+def translate_special_characters(title: str) -> str:
+    # Convert ASCII input into the typographic characters used in Archon Arcana page titles.
+    title = LIGATURE_PATTERN.sub('\u00c6', title)              # AEmber -> Æmber (lowercase "ae" is left alone)
+    title = DOUBLE_QUOTE_PATTERN.sub('\u201c\\1\u201d', title) # "Cloudkicker" -> “Cloudkicker”
+    return title.translate(ASCII_APOSTROPHE_TRANSLATION)       # Nature's -> Nature’s
+
+def entry_to_title(entry: str) -> str:
+    entry = entry.strip()
+
+    if URL_PATTERN.match(entry):
+        match = WIKI_PATH_PATTERN.search(entry)
+        title = match.group(1) if match else entry.rsplit('/', 1)[-1]
+        return unquote(title).replace('_', ' ').strip()
+
+    return entry
+
+def title_to_url(title: str) -> str:
+    return WIKI_PAGE_TEMPLATE.format(title=quote(title.replace(' ', '_'), safe="():,'!*-"))
+
+def search_title(query: str) -> Optional[str]:
+    params = {
+        'action': 'opensearch',
+        'search': query,
+        'limit': '10',
+        'namespace': '0',
+        'format': 'json',
+    }
+
+    results = request_archonarcana(API_URL, params=params).json()
+    titles = results[1] if len(results) > 1 else []
+    if not titles:
+        return None
+
+    normalized_query = normalize_title(query)
+
+    # Prefer an exact match (ignoring case, spaces/underscores, accents, and typographic characters).
+    for title in titles:
+        if normalize_title(title) == normalized_query:
+            return title
+
+    # Last resort: accept the first result if it is a close match.
+    first_title = titles[0]
+    if SequenceMatcher(None, normalized_query, normalize_title(first_title)).ratio() >= FUZZY_MATCH_THRESHOLD:
+        return first_title
+
+    return None
+
+def extract_image_url(html: str) -> Optional[str]:
+    match = IMAGE_ANCHOR_PATTERN.search(html)
+    if not match:
+        return None
+
+    src = unescape(match.group(1))
+
+    # Derive the full-resolution original from the thumbnail URL.
+    return THUMB_PATTERN.sub(r'/\1', src)
+
+def resolve_card(entry: str) -> Tuple[str, str]:
+    title = translate_special_characters(entry_to_title(entry))
+
+    response = request_archonarcana(title_to_url(title), allow_missing=True)
+
+    if response is None:
+        # Exact title not found. Retry via search to handle casing and space/underscore differences.
+        resolved = search_title(title)
+        if resolved is None:
+            raise Exception(f'card not found on Archon Arcana: "{title}"')
+
+        title = resolved
+        response = request_archonarcana(title_to_url(title), allow_missing=True)
+        if response is None:
+            raise Exception(f'card not found on Archon Arcana: "{title}"')
+
+    image_url = extract_image_url(response.text)
+    if image_url is None:
+        raise Exception(f'card image not found on Archon Arcana: "{title}"')
+
+    return title, image_url
+
+def fetch_card_art(index: int, card_name: str, quantity: int, front_img_dir: str):
+    title, image_url = resolve_card(card_name)
+
+    card_art = request_archonarcana(image_url).content
+    clean_name = remove_nonalphanumeric(title)
+
+    for counter in range(quantity):
+        image_path = path.join(front_img_dir, f'{index}{clean_name}{counter + 1}.png')
+
+        with open(image_path, 'wb') as f:
+            f.write(card_art)
+
+def get_handle_card(
+    front_img_dir: str
+):
+    def configured_fetch_card(index: int, card_name: str, quantity: int = 1):
+        fetch_card_art(
+            index,
+            card_name,
+            quantity,
+            front_img_dir
+        )
+
+    return configured_fetch_card

--- a/plugins/keyforge/archonarcana.py
+++ b/plugins/keyforge/archonarcana.py
@@ -108,12 +108,15 @@ def query_page_image(title: str) -> Optional[Tuple[str, Optional[str]]]:
         'piprop': 'original',
         'redirects': '1',
         'format': 'json',
+        # formatversion=2 returns query.pages as an array instead of an object
+        # keyed by page ID, and a real boolean for "missing" instead of "".
+        'formatversion': '2',
     }
 
-    pages = request_archonarcana(API_URL, params=params).json().get('query', {}).get('pages', {})
-    page = next(iter(pages.values()), None)
+    pages = request_archonarcana(API_URL, params=params).json().get('query', {}).get('pages', [])
+    page = pages[0] if pages else None
 
-    if page is None or 'missing' in page:
+    if page is None or page.get('missing'):
         return None
 
     return page.get('title', title), page.get('original', {}).get('source')

--- a/plugins/keyforge/archonarcana.py
+++ b/plugins/keyforge/archonarcana.py
@@ -15,8 +15,6 @@ session = Session()
 USER_AGENT = 'silhouette-card-maker/0.1'
 API_URL = 'https://www.archonarcana.com/w139/api.php'
 
-RATE_LIMIT_SECONDS = 0.075
-
 # Minimum similarity for the last-resort fuzzy match to accept a search result.
 FUZZY_MATCH_THRESHOLD = 0.8
 
@@ -35,7 +33,7 @@ TYPOGRAPHIC_TRANSLATION = str.maketrans({'\u2019': "'", '\u201c': '"', '\u201d':
 def request_archonarcana(url: str, params: Optional[dict] = None) -> Response:
     r = session.get(url, params=params, headers={'user-agent': USER_AGENT, 'accept': '*/*'})
 
-    sleep(RATE_LIMIT_SECONDS)
+    sleep(0.075)
 
     # Check for 2XX response code
     r.raise_for_status()

--- a/plugins/keyforge/archonarcana.py
+++ b/plugins/keyforge/archonarcana.py
@@ -1,20 +1,18 @@
 from difflib import SequenceMatcher
 from functools import partial
-from html import unescape
 from os import path
 from re import IGNORECASE, compile, sub
 from time import sleep
 from typing import Optional, Tuple
 from unicodedata import combining
 from unicodedata import normalize as normalize_unicode
-from urllib.parse import quote, unquote
+from urllib.parse import unquote
 
 from requests import Response, Session
 
 session = Session()
 
 USER_AGENT = 'silhouette-card-maker/0.1'
-WIKI_PAGE_TEMPLATE = 'https://www.archonarcana.com/wiki/{title}'
 API_URL = 'https://www.archonarcana.com/w139/api.php'
 
 RATE_LIMIT_SECONDS = 0.075
@@ -22,10 +20,6 @@ RATE_LIMIT_SECONDS = 0.075
 # Minimum similarity for the last-resort fuzzy match to accept a search result.
 FUZZY_MATCH_THRESHOLD = 0.8
 
-# The card art is the single MediaWiki "image" anchor on a card page.
-IMAGE_ANCHOR_PATTERN = compile(r'<a[^>]*class="image"[^>]*>\s*<img[^>]*\bsrc="([^"]+)"', IGNORECASE)
-# MediaWiki thumbnails look like `.../thumb/<file>/<width>px-<file>`; the original drops the thumb segment.
-THUMB_PATTERN = compile(r'/thumb/(.+)/[^/]+$')
 URL_PATTERN = compile(r'^https?://', IGNORECASE)
 WIKI_PATH_PATTERN = compile(r'/wiki/(.+)$')
 
@@ -37,14 +31,10 @@ ASCII_APOSTROPHE_TRANSLATION = str.maketrans({"'": '\u2019'})
 # Fold those typographic characters back to ASCII so different spellings compare equal.
 TYPOGRAPHIC_TRANSLATION = str.maketrans({'\u2019': "'", '\u201c': '"', '\u201d': '"'})
 
-def request_archonarcana(url: str, params: Optional[dict] = None, allow_missing: bool = False) -> Optional[Response]:
+def request_archonarcana(url: str, params: Optional[dict] = None) -> Response:
     r = session.get(url, params=params, headers={'user-agent': USER_AGENT, 'accept': '*/*'})
 
     sleep(RATE_LIMIT_SECONDS)
-
-    # A missing wiki page responds with 404. Let callers treat that as "does not exist".
-    if allow_missing and r.status_code == 404:
-        return None
 
     # Check for 2XX response code
     r.raise_for_status()
@@ -77,9 +67,6 @@ def entry_to_title(entry: str) -> str:
 
     return entry
 
-def title_to_url(title: str) -> str:
-    return WIKI_PAGE_TEMPLATE.format(title=quote(title.replace(' ', '_'), safe="():,'!*-"))
-
 def search_title(query: str) -> Optional[str]:
     params = {
         'action': 'opensearch',
@@ -108,31 +95,42 @@ def search_title(query: str) -> Optional[str]:
 
     return None
 
-def extract_image_url(html: str) -> Optional[str]:
-    match = IMAGE_ANCHOR_PATTERN.search(html)
-    if not match:
+def query_page_image(title: str) -> Optional[Tuple[str, Optional[str]]]:
+    # Look up a page by title through the MediaWiki API, following redirects. Returns
+    # None if the page does not exist, otherwise (canonical title, original image URL
+    # or None if the page has no image). This avoids fetching and scraping the rendered
+    # wiki page, which the API returns as structured data directly.
+    params = {
+        'action': 'query',
+        'titles': title,
+        'prop': 'pageimages',
+        'piprop': 'original',
+        'redirects': '1',
+        'format': 'json',
+    }
+
+    pages = request_archonarcana(API_URL, params=params).json().get('query', {}).get('pages', {})
+    page = next(iter(pages.values()), None)
+
+    if page is None or 'missing' in page:
         return None
 
-    src = unescape(match.group(1))
-
-    # Derive the full-resolution original from the thumbnail URL.
-    return THUMB_PATTERN.sub(r'/\1', src)
+    return page.get('title', title), page.get('original', {}).get('source')
 
 def resolve_card(entry: str) -> Tuple[str, str]:
     title = translate_special_characters(entry_to_title(entry))
-    response = request_archonarcana(title_to_url(title), allow_missing=True)
+    result = query_page_image(title)
 
-    if response is None:
+    if result is None:
         # Exact title not found. Retry via search to handle casing and space/underscore differences.
         resolved = search_title(title)
         if resolved is not None:
-            title = resolved
-            response = request_archonarcana(title_to_url(title), allow_missing=True)
+            result = query_page_image(resolved)
 
-    if response is None:
+    if result is None:
         raise Exception(f'card not found on Archon Arcana: "{title}"')
 
-    image_url = extract_image_url(response.text)
+    title, image_url = result
     if image_url is None:
         raise Exception(f'card image not found on Archon Arcana: "{title}"')
 

--- a/plugins/keyforge/archonarcana.py
+++ b/plugins/keyforge/archonarcana.py
@@ -77,6 +77,8 @@ def search_title(query: str) -> Optional[str]:
         'format': 'json',
     }
 
+    # action=opensearch responds with a 4-element array, not an object:
+    # [query, [matched titles], [descriptions], [urls]]. Index 1 is the titles.
     results = request_archonarcana(API_URL, params=params).json()
     titles = results[1] if len(results) > 1 else []
     if not titles:

--- a/plugins/keyforge/archonarcana.py
+++ b/plugins/keyforge/archonarcana.py
@@ -141,7 +141,7 @@ def resolve_card(entry: str) -> Tuple[str, str]:
 
     return title, image_url
 
-def fetch_card_art(index: int, card_name: str, quantity: int, front_img_dir: str):
+def fetch_card(index: int, card_name: str, quantity: int, front_img_dir: str):
     title, image_url = resolve_card(card_name)
 
     card_art = request_archonarcana(image_url).content
@@ -154,4 +154,4 @@ def fetch_card_art(index: int, card_name: str, quantity: int, front_img_dir: str
             f.write(card_art)
 
 def get_handle_card(front_img_dir: str):
-    return partial(fetch_card_art, front_img_dir=front_img_dir)
+    return partial(fetch_card, front_img_dir=front_img_dir)

--- a/plugins/keyforge/deck_formats.py
+++ b/plugins/keyforge/deck_formats.py
@@ -5,7 +5,10 @@ from plugins.keyforge.archonarcana import entry_to_title, normalize_title
 from plugins.keyforge.mastervault import (card_count_tuple, extract_deck_id,
                                            get_deck_card_counts)
 
-def run_cards(cards: List[card_count_tuple], handle_card: Callable) -> None:
+# Unlike other plugins' parse_deck_helper, this takes an already-aggregated
+# (reference, quantity) list rather than raw deck_text + line-matcher callables:
+# archon_arcana lines don't state a quantity, so duplicates must be counted first.
+def parse_deck_helper(cards: List[card_count_tuple], handle_card: Callable) -> None:
     error_lines = []
 
     index = 0
@@ -48,7 +51,7 @@ def parse_archon_arcana(deck_text: str, handle_card: Callable) -> None:
 
         cards[key][1] += 1
 
-    run_cards([(reference, quantity) for reference, quantity in cards.values()], handle_card)
+    parse_deck_helper([(reference, quantity) for reference, quantity in cards.values()], handle_card)
 
 def parse_deck_url(deck_text: str, handle_card: Callable) -> None:
     cards = []
@@ -70,7 +73,7 @@ def parse_deck_url(deck_text: str, handle_card: Callable) -> None:
         for line, error in error_lines:
             print(f'  - {line} ({error})')
 
-    run_cards(cards, handle_card)
+    parse_deck_helper(cards, handle_card)
 
 class DeckFormat(str, Enum):
     ARCHON_ARCANA = 'archon_arcana'

--- a/plugins/keyforge/deck_formats.py
+++ b/plugins/keyforge/deck_formats.py
@@ -56,12 +56,23 @@ def parse_archon_arcana(deck_text: str, handle_card: Callable) -> None:
 
 def parse_deck_url(deck_text: str, handle_card: Callable) -> None:
     cards = []
+    error_lines = []
 
     # Each line is a deck URL. Master Vault and Decks of KeyForge share the same deck ID,
     # so both are resolved through Master Vault and can be mixed together.
     for line in read_lines(deck_text):
-        deck_id = extract_deck_id(line)
-        cards.extend(get_deck_card_counts(deck_id))
+        try:
+            deck_id = extract_deck_id(line)
+            cards.extend(get_deck_card_counts(deck_id))
+        except Exception as e:
+            print(f'Error: {e}')
+            error_lines.append((line, str(e)))
+
+    if len(error_lines) > 0:
+        print()
+        print(f'{len(error_lines)} deck(s) did not work:')
+        for line, error in error_lines:
+            print(f'  - {line} ({error})')
 
     run_cards(cards, handle_card)
 

--- a/plugins/keyforge/deck_formats.py
+++ b/plugins/keyforge/deck_formats.py
@@ -1,0 +1,78 @@
+from enum import Enum
+from typing import Callable, List, Tuple
+
+from plugins.keyforge.archonarcana import entry_to_title, normalize_title
+from plugins.keyforge.mastervault import extract_deck_id, get_deck_card_counts
+
+card_count_tuple = Tuple[str, int] # card reference, quantity
+
+def run_cards(cards: List[card_count_tuple], handle_card: Callable) -> None:
+    error_lines = []
+
+    index = 0
+    for name, quantity in cards:
+        index = index + 1
+
+        print(f'Index: {index}, quantity: {quantity}, name: {name}')
+        try:
+            handle_card(index, name, quantity)
+        except Exception as e:
+            print(f'Error: {e}')
+            error_lines.append((name, str(e)))
+
+    if len(error_lines) > 0:
+        print()
+        print(f'{len(error_lines)} card(s) did not work:')
+        for name, error in error_lines:
+            print(f'  - {name} ({error})')
+
+def read_lines(deck_text: str):
+    for raw_line in deck_text.splitlines():
+        line = raw_line.strip()
+
+        # Skip blank lines and comments.
+        if not line or line.startswith('#') or line.startswith('//'):
+            continue
+
+        yield line
+
+def parse_archon_arcana(deck_text: str, handle_card: Callable) -> None:
+    # Aggregate repeated cards into quantities, preserving first-seen order.
+    ordered_keys = []
+    counts = {}
+    references = {}
+
+    for line in read_lines(deck_text):
+        key = normalize_title(entry_to_title(line))
+
+        if key not in counts:
+            counts[key] = 0
+            ordered_keys.append(key)
+            references[key] = line
+
+        counts[key] = counts[key] + 1
+
+    run_cards([(references[key], counts[key]) for key in ordered_keys], handle_card)
+
+def parse_deck_url(deck_text: str, handle_card: Callable) -> None:
+    cards = []
+
+    # Each line is a deck URL. Master Vault and Decks of KeyForge share the same deck ID,
+    # so both are resolved through Master Vault and can be mixed together.
+    for line in read_lines(deck_text):
+        deck_id = extract_deck_id(line)
+        cards.extend(get_deck_card_counts(deck_id))
+
+    run_cards(cards, handle_card)
+
+class DeckFormat(str, Enum):
+    ARCHON_ARCANA = 'archon_arcana'
+    MASTER_VAULT = 'master_vault'
+
+def parse_deck(deck_text: str, format: DeckFormat, handle_card: Callable) -> None:
+    if format == DeckFormat.ARCHON_ARCANA:
+        parse_archon_arcana(deck_text, handle_card)
+    elif format == DeckFormat.MASTER_VAULT:
+        parse_deck_url(deck_text, handle_card)
+    else:
+        raise ValueError('Unrecognized deck format.')

--- a/plugins/keyforge/deck_formats.py
+++ b/plugins/keyforge/deck_formats.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from os.path import isfile
 from typing import Callable, List
 
 from plugins.keyforge.archonarcana import entry_to_title, normalize_title
@@ -54,11 +55,15 @@ def parse_archon_arcana(deck_text: str, handle_card: Callable) -> None:
     parse_deck_helper([(reference, quantity) for reference, quantity in cards.values()], handle_card)
 
 def parse_deck_url(deck_text: str, handle_card: Callable) -> None:
+    if isfile(deck_text):
+        with open(deck_text, 'r') as deck_file:
+            deck_text = deck_file.read()
+
     cards = []
     error_lines = []
 
     # Each line is a deck URL. Master Vault and Decks of KeyForge share the same deck ID,
-    # so both are resolved through Master Vault and can be mixed together.
+    # so both are resolved through Master Vault regardless of which format was selected.
     for line in read_lines(deck_text):
         try:
             deck_id = extract_deck_id(line)
@@ -77,12 +82,13 @@ def parse_deck_url(deck_text: str, handle_card: Callable) -> None:
 
 class DeckFormat(str, Enum):
     ARCHON_ARCANA = 'archon_arcana'
-    MASTER_VAULT = 'master_vault'
+    MASTER_VAULT_URL = 'master_vault_url'
+    DECKS_OF_KEYFORGE_URL = 'decks_of_keyforge_url'
 
 def parse_deck(deck_text: str, format: DeckFormat, handle_card: Callable) -> None:
     if format == DeckFormat.ARCHON_ARCANA:
         parse_archon_arcana(deck_text, handle_card)
-    elif format == DeckFormat.MASTER_VAULT:
+    elif format in (DeckFormat.MASTER_VAULT_URL, DeckFormat.DECKS_OF_KEYFORGE_URL):
         parse_deck_url(deck_text, handle_card)
     else:
         raise ValueError('Unrecognized deck format.')

--- a/plugins/keyforge/deck_formats.py
+++ b/plugins/keyforge/deck_formats.py
@@ -1,10 +1,9 @@
 from enum import Enum
-from typing import Callable, List, Tuple
+from typing import Callable, List
 
 from plugins.keyforge.archonarcana import entry_to_title, normalize_title
-from plugins.keyforge.mastervault import extract_deck_id, get_deck_card_counts
-
-card_count_tuple = Tuple[str, int] # card reference, quantity
+from plugins.keyforge.mastervault import (card_count_tuple, extract_deck_id,
+                                           get_deck_card_counts)
 
 def run_cards(cards: List[card_count_tuple], handle_card: Callable) -> None:
     error_lines = []
@@ -37,22 +36,19 @@ def read_lines(deck_text: str):
         yield line
 
 def parse_archon_arcana(deck_text: str, handle_card: Callable) -> None:
-    # Aggregate repeated cards into quantities, preserving first-seen order.
-    ordered_keys = []
-    counts = {}
-    references = {}
+    # Aggregate repeated cards into quantities, keyed by normalized title. A dict
+    # preserves insertion order, so this also keeps cards in first-seen order.
+    cards = {}
 
     for line in read_lines(deck_text):
         key = normalize_title(entry_to_title(line))
 
-        if key not in counts:
-            counts[key] = 0
-            ordered_keys.append(key)
-            references[key] = line
+        if key not in cards:
+            cards[key] = [line, 0]
 
-        counts[key] = counts[key] + 1
+        cards[key][1] += 1
 
-    run_cards([(references[key], counts[key]) for key in ordered_keys], handle_card)
+    run_cards([(reference, quantity) for reference, quantity in cards.values()], handle_card)
 
 def parse_deck_url(deck_text: str, handle_card: Callable) -> None:
     cards = []

--- a/plugins/keyforge/fetch.py
+++ b/plugins/keyforge/fetch.py
@@ -1,0 +1,39 @@
+import sys
+from os import path
+
+from click import Choice, argument, command
+
+# Add parent directory to path to allow imports when run as a script
+REPO_ROOT = path.abspath(path.join(path.dirname(__file__), '..', '..'))
+sys.path.insert(0, REPO_ROOT)
+
+from plugins.keyforge.archonarcana import get_handle_card
+from plugins.keyforge.deck_formats import DeckFormat, parse_deck
+from utilities import ensure_directory
+
+front_directory = path.join(REPO_ROOT, 'game', 'front')
+
+@command()
+@argument('deck_path')
+@argument('format', type=Choice([t.value for t in DeckFormat], case_sensitive=False))
+
+def cli(deck_path: str, format: DeckFormat):
+    ensure_directory(front_directory)
+
+    if not path.isfile(deck_path):
+        print(f'{deck_path} is not a valid file.')
+        return
+
+    with open(deck_path, 'r') as deck_file:
+        deck_text = deck_file.read()
+
+        parse_deck(
+            deck_text,
+            format,
+            get_handle_card(
+                front_directory
+            )
+        )
+
+if __name__ == '__main__':
+    cli()

--- a/plugins/keyforge/fetch.py
+++ b/plugins/keyforge/fetch.py
@@ -20,20 +20,23 @@ front_directory = path.join(REPO_ROOT, 'game', 'front')
 def cli(deck_path: str, format: DeckFormat):
     ensure_directory(front_directory)
 
-    if not path.isfile(deck_path):
-        print(f'{deck_path} is not a valid file.')
-        return
+    if format in (DeckFormat.MASTER_VAULT_URL, DeckFormat.DECKS_OF_KEYFORGE_URL):
+        deck_text = deck_path
+    else:
+        if not path.isfile(deck_path):
+            print(f'{deck_path} is not a valid file.')
+            return
 
-    with open(deck_path, 'r') as deck_file:
-        deck_text = deck_file.read()
+        with open(deck_path, 'r') as deck_file:
+            deck_text = deck_file.read()
 
-        parse_deck(
-            deck_text,
-            format,
-            get_handle_card(
-                front_directory
-            )
+    parse_deck(
+        deck_text,
+        format,
+        get_handle_card(
+            front_directory
         )
+    )
 
 if __name__ == '__main__':
     cli()

--- a/plugins/keyforge/mastervault.py
+++ b/plugins/keyforge/mastervault.py
@@ -40,8 +40,8 @@ def get_deck_card_counts(deck_id: str) -> List[card_count_tuple]:
     cards_by_id = {card['id']: card for card in linked_cards}
 
     def card_name(card: dict) -> str:
-        # Archon Arcana uses English card titles.
-        return card.get('card_title_en') or card.get('card_title')
+        # Archon Arcana uses English card titles
+        return card.get('card_title_en') or card['card_title']
 
     # A dict preserves insertion order, so counts stay in the deck's card order.
     counts = {}

--- a/plugins/keyforge/mastervault.py
+++ b/plugins/keyforge/mastervault.py
@@ -1,0 +1,58 @@
+from re import IGNORECASE, compile
+from time import sleep
+from typing import List, Tuple
+
+import cloudscraper
+
+# Master Vault sits behind Cloudflare, so use cloudscraper with its default browser fingerprint.
+scraper = cloudscraper.create_scraper()
+
+DECK_API_TEMPLATE = 'https://www.keyforgegame.com/api/decks/{deck_id}/?links=cards'
+
+# Decks of KeyForge and Master Vault both key decks by the same UUID.
+UUID_PATTERN = compile(r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}', IGNORECASE)
+
+RATE_LIMIT_SECONDS = 0.075
+
+card_count_tuple = Tuple[str, int] # card name, quantity
+
+def request_mastervault(url: str):
+    r = scraper.get(url, headers={'accept': 'application/json'})
+
+    # Check for 2XX response code
+    r.raise_for_status()
+
+    sleep(RATE_LIMIT_SECONDS)
+
+    return r
+
+def extract_deck_id(url: str) -> str:
+    match = UUID_PATTERN.search(url)
+    if not match:
+        raise Exception(f'could not find a deck ID in "{url}"')
+
+    return match.group(0)
+
+def get_deck_card_counts(deck_id: str) -> List[card_count_tuple]:
+    data = request_mastervault(DECK_API_TEMPLATE.format(deck_id=deck_id)).json()
+
+    linked_cards = data.get('_linked', {}).get('cards', [])
+    cards_by_id = {card['id']: card for card in linked_cards}
+
+    def card_name(card: dict) -> str:
+        # Archon Arcana uses English card titles.
+        return card.get('card_title_en') or card.get('card_title')
+
+    # A dict preserves insertion order, so counts stay in the deck's card order.
+    counts = {}
+
+    def add_card(name: str) -> None:
+        counts[name] = counts.get(name, 0) + 1
+
+    # data._links.cards lists every card in the deck including non-deck cards such as Prophecies
+    for card_id in data.get('data', {}).get('_links', {}).get('cards', []):
+        card = cards_by_id.get(card_id)
+        if card is not None:
+            add_card(card_name(card))
+
+    return list(counts.items())

--- a/plugins/keyforge/mastervault.py
+++ b/plugins/keyforge/mastervault.py
@@ -12,8 +12,6 @@ DECK_API_TEMPLATE = 'https://www.keyforgegame.com/api/decks/{deck_id}/?links=car
 # Decks of KeyForge and Master Vault both key decks by the same UUID.
 UUID_PATTERN = compile(r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}', IGNORECASE)
 
-RATE_LIMIT_SECONDS = 0.075
-
 card_count_tuple = Tuple[str, int] # card name or reference, quantity
 
 def request_mastervault(url: str):
@@ -22,7 +20,7 @@ def request_mastervault(url: str):
     # Check for 2XX response code
     r.raise_for_status()
 
-    sleep(RATE_LIMIT_SECONDS)
+    sleep(0.075)
 
     return r
 

--- a/plugins/keyforge/mastervault.py
+++ b/plugins/keyforge/mastervault.py
@@ -37,22 +37,19 @@ def get_deck_card_counts(deck_id: str) -> List[card_count_tuple]:
     linked_cards = data.get('_linked', {}).get('cards', [])
     cards_by_id = {card.get('id'): card for card in linked_cards if card.get('id') is not None}
 
-    def card_name(card_id: str, card: dict) -> str:
+    # data._links.cards lists every card in the deck in order, including non-deck
+    # cards such as Prophecies. A dict preserves insertion order, so counts stay
+    # in the deck's card order too.
+    counts = {}
+    for card_id in data.get('data', {}).get('_links', {}).get('cards', []):
+        card = cards_by_id.get(card_id)
+        if card is None:
+            continue
+
         # Archon Arcana uses English card titles. Fall back to the card ID if
         # neither title field is present rather than raising, matching the
         # arkham_horror_lcg plugin's card.get('name') or code convention.
-        return card.get('card_title_en') or card.get('card_title') or card_id
-
-    # A dict preserves insertion order, so counts stay in the deck's card order.
-    counts = {}
-
-    def add_card(name: str) -> None:
+        name = card.get('card_title_en') or card.get('card_title') or card_id
         counts[name] = counts.get(name, 0) + 1
-
-    # data._links.cards lists every card in the deck including non-deck cards such as Prophecies
-    for card_id in data.get('data', {}).get('_links', {}).get('cards', []):
-        card = cards_by_id.get(card_id)
-        if card is not None:
-            add_card(card_name(card_id, card))
 
     return list(counts.items())

--- a/plugins/keyforge/mastervault.py
+++ b/plugins/keyforge/mastervault.py
@@ -14,7 +14,7 @@ UUID_PATTERN = compile(r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f
 
 RATE_LIMIT_SECONDS = 0.075
 
-card_count_tuple = Tuple[str, int] # card name, quantity
+card_count_tuple = Tuple[str, int] # card name or reference, quantity
 
 def request_mastervault(url: str):
     r = scraper.get(url, headers={'accept': 'application/json'})

--- a/plugins/keyforge/mastervault.py
+++ b/plugins/keyforge/mastervault.py
@@ -37,11 +37,13 @@ def get_deck_card_counts(deck_id: str) -> List[card_count_tuple]:
     data = request_mastervault(DECK_API_TEMPLATE.format(deck_id=deck_id)).json()
 
     linked_cards = data.get('_linked', {}).get('cards', [])
-    cards_by_id = {card['id']: card for card in linked_cards}
+    cards_by_id = {card.get('id'): card for card in linked_cards if card.get('id') is not None}
 
-    def card_name(card: dict) -> str:
-        # Archon Arcana uses English card titles
-        return card.get('card_title_en') or card['card_title']
+    def card_name(card_id: str, card: dict) -> str:
+        # Archon Arcana uses English card titles. Fall back to the card ID if
+        # neither title field is present rather than raising, matching the
+        # arkham_horror_lcg plugin's card.get('name') or code convention.
+        return card.get('card_title_en') or card.get('card_title') or card_id
 
     # A dict preserves insertion order, so counts stay in the deck's card order.
     counts = {}
@@ -53,6 +55,6 @@ def get_deck_card_counts(deck_id: str) -> List[card_count_tuple]:
     for card_id in data.get('data', {}).get('_links', {}).get('cards', []):
         card = cards_by_id.get(card_id)
         if card is not None:
-            add_card(card_name(card))
+            add_card(card_name(card_id, card))
 
     return list(counts.items())

--- a/test/test_keyforge_plugin.py
+++ b/test/test_keyforge_plugin.py
@@ -35,11 +35,8 @@ class TestDeckFormatEnum:
 
     def test_format_values(self):
         assert DeckFormat.ARCHON_ARCANA.value == 'archon_arcana'
-        assert DeckFormat.MASTER_VAULT.value == 'master_vault'
-
-    def test_no_separate_decks_of_keyforge_format(self):
-        # Decks of KeyForge URLs are handled by the master_vault format.
-        assert not hasattr(DeckFormat, 'DECKS_OF_KEYFORGE')
+        assert DeckFormat.MASTER_VAULT_URL.value == 'master_vault_url'
+        assert DeckFormat.DECKS_OF_KEYFORGE_URL.value == 'decks_of_keyforge_url'
 
 
 # --- Unit Tests for Special Character Translation ---
@@ -289,6 +286,31 @@ class TestGetDeckCardCountsDefensive:
         assert cards == [('Title', 1)]
 
 
+# --- Unit Tests for master_vault_url/decks_of_keyforge_url Accepting a File or a Literal URL ---
+
+class TestParseDeckUrlFileOrLiteral:
+    """parse_deck_url should accept either a path to a file of deck URLs or a single URL."""
+
+    def test_reads_deck_urls_from_a_file(self, tmp_path):
+        deck_file = tmp_path / 'deck.txt'
+        deck_file.write_text('deck-from-file')
+
+        collected = []
+        with patch.object(deck_formats, 'extract_deck_id', return_value='deck-from-file'), \
+             patch.object(deck_formats, 'get_deck_card_counts', return_value=[('a card', 1)]):
+            parse_deck_url(str(deck_file), lambda index, name, quantity: collected.append((index, name, quantity)))
+
+        assert collected == [(1, 'a card', 1)]
+
+    def test_treats_non_file_text_as_a_literal_url(self):
+        collected = []
+        with patch.object(deck_formats, 'extract_deck_id', return_value='literal-deck-id'), \
+             patch.object(deck_formats, 'get_deck_card_counts', return_value=[('a card', 1)]):
+            parse_deck_url('https://www.keyforgegame.com/deck-details/not-a-file-path', lambda index, name, quantity: collected.append((index, name, quantity)))
+
+        assert collected == [(1, 'a card', 1)]
+
+
 # --- Unit Tests for Master Vault Multi-Deck URL Batches ---
 
 class TestParseDeckUrlResilience:
@@ -447,7 +469,16 @@ class TestFullFetchWorkflow:
 
     @pytest.mark.slow
     def test_fetch_master_vault_deck(self, temp_dir):
-        parse_deck(MASTER_VAULT_URL, DeckFormat.MASTER_VAULT, get_handle_card(temp_dir))
+        parse_deck(MASTER_VAULT_URL, DeckFormat.MASTER_VAULT_URL, get_handle_card(temp_dir))
+
+        files = os.listdir(temp_dir)
+        assert len(files) >= 1
+        for f in files:
+            assert os.path.getsize(os.path.join(temp_dir, f)) > 0
+
+    @pytest.mark.slow
+    def test_fetch_decks_of_keyforge_deck(self, temp_dir):
+        parse_deck(DECKS_OF_KEYFORGE_URL, DeckFormat.DECKS_OF_KEYFORGE_URL, get_handle_card(temp_dir))
 
         files = os.listdir(temp_dir)
         assert len(files) >= 1

--- a/test/test_keyforge_plugin.py
+++ b/test/test_keyforge_plugin.py
@@ -5,9 +5,11 @@ Tests deck format parsing, Archon Arcana card resolution, and Master Vault deck 
 import os
 import shutil
 import tempfile
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from plugins.keyforge import deck_formats, mastervault
 from plugins.keyforge.archonarcana import (API_URL, entry_to_title,
                                            extract_image_url, get_handle_card,
                                            normalize_title,
@@ -15,7 +17,7 @@ from plugins.keyforge.archonarcana import (API_URL, entry_to_title,
                                            request_archonarcana, resolve_card,
                                            translate_special_characters)
 from plugins.keyforge.deck_formats import (DeckFormat, parse_archon_arcana,
-                                           parse_deck)
+                                           parse_deck, parse_deck_url)
 from plugins.keyforge.mastervault import extract_deck_id, get_deck_card_counts
 
 # A stable, public deck used for Master Vault integration tests.
@@ -142,6 +144,85 @@ class TestMasterVaultDeckId:
     def test_raises_without_uuid(self):
         with pytest.raises(Exception):
             extract_deck_id('https://decksofkeyforge.com/decks/not-a-real-id')
+
+
+# --- Unit Tests for Master Vault Defensive Field Access ---
+
+class TestGetDeckCardCountsDefensive:
+    """Test get_deck_card_counts against malformed/incomplete API data."""
+
+    def _fake_response(self, data: dict):
+        response = MagicMock()
+        response.json.return_value = data
+        return response
+
+    def test_missing_title_fields_falls_back_to_card_id(self):
+        # A card record missing both card_title_en and card_title (e.g. an
+        # unannounced/non-standard card) must not raise a KeyError.
+        data = {
+            '_linked': {'cards': [{'id': 'card-1'}]},
+            'data': {'_links': {'cards': ['card-1']}},
+        }
+        with patch.object(mastervault, 'request_mastervault', return_value=self._fake_response(data)):
+            cards = mastervault.get_deck_card_counts('deck-1')
+
+        assert cards == [('card-1', 1)]
+
+    def test_missing_id_is_skipped_without_crashing(self):
+        # A linked card missing 'id' must be skipped rather than raising a KeyError.
+        data = {
+            '_linked': {'cards': [{'card_title': 'Ecto-Charge'}]},
+            'data': {'_links': {'cards': ['card-1']}},
+        }
+        with patch.object(mastervault, 'request_mastervault', return_value=self._fake_response(data)):
+            cards = mastervault.get_deck_card_counts('deck-1')
+
+        assert cards == []
+
+    def test_prefers_english_title_over_localized_title(self):
+        data = {
+            '_linked': {'cards': [{'id': 'card-1', 'card_title': 'Titre', 'card_title_en': 'Title'}]},
+            'data': {'_links': {'cards': ['card-1']}},
+        }
+        with patch.object(mastervault, 'request_mastervault', return_value=self._fake_response(data)):
+            cards = mastervault.get_deck_card_counts('deck-1')
+
+        assert cards == [('Title', 1)]
+
+
+# --- Unit Tests for Master Vault Multi-Deck URL Batches ---
+
+class TestParseDeckUrlResilience:
+    """A bad deck URL must not drop decks already fetched earlier in the batch."""
+
+    def test_bad_deck_does_not_drop_already_fetched_decks(self):
+        def fake_extract_deck_id(line):
+            if 'bad' in line:
+                raise Exception(f'could not find a deck ID in "{line}"')
+            return line
+
+        def fake_get_deck_card_counts(deck_id):
+            return [(f'{deck_id}-card', 1)]
+
+        deck_text = '\n'.join(['good-deck-1', 'bad-deck', 'good-deck-2'])
+
+        collected = []
+        with patch.object(deck_formats, 'extract_deck_id', side_effect=fake_extract_deck_id), \
+             patch.object(deck_formats, 'get_deck_card_counts', side_effect=fake_get_deck_card_counts):
+            parse_deck_url(deck_text, lambda index, name, quantity: collected.append((index, name, quantity)))
+
+        names = [name for _, name, _ in collected]
+        assert names == ['good-deck-1-card', 'good-deck-2-card']
+
+    def test_all_decks_bad_reports_errors_and_fetches_nothing(self):
+        def fake_extract_deck_id(line):
+            raise Exception(f'could not find a deck ID in "{line}"')
+
+        collected = []
+        with patch.object(deck_formats, 'extract_deck_id', side_effect=fake_extract_deck_id):
+            parse_deck_url('bad-deck-1\nbad-deck-2', lambda index, name, quantity: collected.append((index, name, quantity)))
+
+        assert collected == []
 
 
 # --- Unit Tests for Archon Arcana List Format ---

--- a/test/test_keyforge_plugin.py
+++ b/test/test_keyforge_plugin.py
@@ -101,6 +101,12 @@ class TestEntryToTitle:
         # L%C3%A6rie -> Lærie
         assert entry_to_title('https://www.archonarcana.com/wiki/L%C3%A6rie_of_the_Lake') == 'L\u00e6rie of the Lake'
 
+    def test_url_query_string_excluded(self):
+        assert entry_to_title('https://www.archonarcana.com/wiki/Ecto-Charge?action=history') == 'Ecto-Charge'
+
+    def test_url_fragment_excluded(self):
+        assert entry_to_title('https://www.archonarcana.com/wiki/Ecto-Charge#Card') == 'Ecto-Charge'
+
 
 class TestRemoveNonalphanumeric:
     """Test the filename sanitizer."""
@@ -203,6 +209,16 @@ class TestResolveCard:
              patch.object(archonarcana, 'search_title', return_value='Resolved Title'):
             with pytest.raises(Exception, match='card not found'):
                 resolve_card('ecto charge')
+
+    def test_skips_redundant_requery_when_search_resolves_to_same_title(self):
+        # If search_title's exact-match branch returns the title already tried
+        # directly, re-querying it would just repeat the same miss.
+        with patch.object(archonarcana, 'query_page_image', return_value=None) as mock_query, \
+             patch.object(archonarcana, 'search_title', return_value='Ecto-Charge'):
+            with pytest.raises(Exception, match='card not found'):
+                resolve_card('Ecto-Charge')
+
+            mock_query.assert_called_once_with('Ecto-Charge')
 
     def test_raises_when_page_has_no_image(self):
         with patch.object(archonarcana, 'query_page_image', return_value=('Some Page', None)), \

--- a/test/test_keyforge_plugin.py
+++ b/test/test_keyforge_plugin.py
@@ -129,13 +129,13 @@ class TestQueryPageImage:
     def test_returns_title_and_image_for_existing_page(self):
         data = {
             'query': {
-                'pages': {
-                    '11067': {
+                'pages': [
+                    {
                         'pageid': 11067,
                         'title': 'Ecto-Charge',
                         'original': {'source': 'https://example.com/939-070.png'},
                     }
-                }
+                ]
             }
         }
         with patch.object(archonarcana, 'request_archonarcana', return_value=self._fake_response(data)):
@@ -147,13 +147,13 @@ class TestQueryPageImage:
         data = {
             'query': {
                 'redirects': [{'from': 'Ecto Charge', 'to': 'Ecto-Charge'}],
-                'pages': {
-                    '11067': {
+                'pages': [
+                    {
                         'pageid': 11067,
                         'title': 'Ecto-Charge',
                         'original': {'source': 'https://example.com/939-070.png'},
                     }
-                }
+                ]
             }
         }
         with patch.object(archonarcana, 'request_archonarcana', return_value=self._fake_response(data)):
@@ -162,9 +162,7 @@ class TestQueryPageImage:
     def test_returns_title_with_none_image_when_page_has_no_image(self):
         data = {
             'query': {
-                'pages': {
-                    '123': {'pageid': 123, 'title': 'Some Page'}
-                }
+                'pages': [{'pageid': 123, 'title': 'Some Page'}]
             }
         }
         with patch.object(archonarcana, 'request_archonarcana', return_value=self._fake_response(data)):
@@ -173,13 +171,16 @@ class TestQueryPageImage:
     def test_returns_none_for_missing_page(self):
         data = {
             'query': {
-                'pages': {
-                    '-1': {'title': 'Not A Real Card', 'missing': ''}
-                }
+                'pages': [{'title': 'Not A Real Card', 'missing': True}]
             }
         }
         with patch.object(archonarcana, 'request_archonarcana', return_value=self._fake_response(data)):
             assert query_page_image('Not A Real Card') is None
+
+    def test_returns_none_for_empty_pages_array(self):
+        data = {'query': {'pages': []}}
+        with patch.object(archonarcana, 'request_archonarcana', return_value=self._fake_response(data)):
+            assert query_page_image('Anything') is None
 
 
 # --- Unit Tests for Card Resolution Control Flow ---

--- a/test/test_keyforge_plugin.py
+++ b/test/test_keyforge_plugin.py
@@ -1,0 +1,275 @@
+"""
+Tests for the KeyForge plugin.
+Tests deck format parsing, Archon Arcana card resolution, and Master Vault deck loading.
+"""
+import os
+import shutil
+import tempfile
+
+import pytest
+
+from plugins.keyforge.archonarcana import (API_URL, entry_to_title,
+                                           extract_image_url, get_handle_card,
+                                           normalize_title,
+                                           remove_nonalphanumeric,
+                                           request_archonarcana, resolve_card,
+                                           translate_special_characters)
+from plugins.keyforge.deck_formats import (DeckFormat, parse_archon_arcana,
+                                           parse_deck)
+from plugins.keyforge.mastervault import extract_deck_id, get_deck_card_counts
+
+# A stable, public deck used for Master Vault integration tests.
+# It contains 36 deck cards + 4 Prophecy (non-deck) cards = 40 total,
+# and 3 copies of "Gracchan Reform".
+SAMPLE_DECK_ID = '4b86855f-71e5-4f54-a20d-2a58ec973f9c'
+MASTER_VAULT_URL = f'https://www.keyforgegame.com/deck-details/{SAMPLE_DECK_ID}'
+DECKS_OF_KEYFORGE_URL = f'https://decksofkeyforge.com/decks/{SAMPLE_DECK_ID}'
+
+
+# --- Unit Tests for Deck Format Enum ---
+
+class TestDeckFormatEnum:
+    """Test the DeckFormat enum values."""
+
+    def test_format_values(self):
+        assert DeckFormat.ARCHON_ARCANA.value == 'archon_arcana'
+        assert DeckFormat.MASTER_VAULT.value == 'master_vault'
+
+    def test_no_separate_decks_of_keyforge_format(self):
+        # Decks of KeyForge URLs are handled by the master_vault format.
+        assert not hasattr(DeckFormat, 'DECKS_OF_KEYFORGE')
+
+
+# --- Unit Tests for Special Character Translation ---
+
+class TestTranslateSpecialCharacters:
+    """Test ASCII-to-typographic translation used for Archon Arcana titles."""
+
+    def test_ae_ligature(self):
+        assert translate_special_characters('AEmber Imp') == '\u00c6mber Imp'
+
+    def test_lowercase_ae_not_translated(self):
+        # Only uppercase "AE" is folded to "Æ"; lowercase "ae" is left alone.
+        assert translate_special_characters('aember imp') == 'aember imp'
+        assert translate_special_characters('Praetor') == 'Praetor'
+
+    def test_apostrophe(self):
+        assert translate_special_characters("Nature's Call") == 'Nature\u2019s Call'
+
+    def test_double_quotes(self):
+        assert translate_special_characters('Shae "Cloudkicker"') == 'Shae \u201cCloudkicker\u201d'
+
+    def test_plain_name_unchanged(self):
+        assert translate_special_characters('Gracchan Reform') == 'Gracchan Reform'
+
+
+# --- Unit Tests for Title Normalization ---
+
+class TestNormalizeTitle:
+    """Test the normalization used for matching and de-duplication."""
+
+    def test_case_space_and_underscore_equivalent(self):
+        assert normalize_title('Gracchan_Reform') == normalize_title('gracchan reform')
+
+    def test_accents_folded(self):
+        assert normalize_title('G\u0115zdruty\u014f the Arcane') == 'gezdrutyo the arcane'
+
+    def test_ae_ligature_folded_to_ae(self):
+        assert normalize_title('\u00c6mber Imp') == normalize_title('AEmber Imp') == 'aember imp'
+
+    def test_apostrophe_variants_equal(self):
+        assert normalize_title("Nature's Call") == normalize_title('Nature\u2019s Call')
+
+    def test_quote_variants_equal(self):
+        assert normalize_title('Shae "Cloudkicker"') == normalize_title('Shae \u201cCloudkicker\u201d')
+
+
+# --- Unit Tests for Entry Parsing ---
+
+class TestEntryToTitle:
+    """Test extracting a wiki title from an input line."""
+
+    def test_name_passthrough(self):
+        assert entry_to_title('Ecto-Charge') == 'Ecto-Charge'
+
+    def test_url_extraction(self):
+        assert entry_to_title('https://www.archonarcana.com/wiki/Gracchan_Reform') == 'Gracchan Reform'
+
+    def test_url_percent_decoding(self):
+        # L%C3%A6rie -> Lærie
+        assert entry_to_title('https://www.archonarcana.com/wiki/L%C3%A6rie_of_the_Lake') == 'L\u00e6rie of the Lake'
+
+
+class TestRemoveNonalphanumeric:
+    """Test the filename sanitizer."""
+
+    def test_removes_spaces_and_punctuation(self):
+        assert remove_nonalphanumeric('Reassembly Required') == 'ReassemblyRequired'
+        assert remove_nonalphanumeric('Shae \u201cCloudkicker\u201d') == 'ShaeCloudkicker'
+
+
+# --- Unit Tests for Image URL Extraction ---
+
+class TestExtractImageUrl:
+    """Test deriving the full-resolution image URL from page HTML."""
+
+    def test_derives_original_from_thumbnail(self):
+        html = (
+            '<a href="/wiki/File:939-070.png" class="image">'
+            '<img alt="Ecto-Charge" '
+            'src="https://mywikis-wiki-media.s3.us-central-1.wasabisys.com/archonarcana/thumb/939-070.png/300px-939-070.png" '
+            'width="300" height="420">'
+        )
+        assert extract_image_url(html) == (
+            'https://mywikis-wiki-media.s3.us-central-1.wasabisys.com/archonarcana/939-070.png'
+        )
+
+    def test_returns_none_without_image(self):
+        assert extract_image_url('<p>This page has no card image.</p>') is None
+
+
+# --- Unit Tests for Master Vault Deck ID Extraction ---
+
+class TestMasterVaultDeckId:
+    """Test extracting the deck ID from Master Vault and Decks of KeyForge URLs."""
+
+    def test_extract_from_master_vault_url(self):
+        assert extract_deck_id(MASTER_VAULT_URL) == SAMPLE_DECK_ID
+
+    def test_extract_from_decks_of_keyforge_url(self):
+        assert extract_deck_id(DECKS_OF_KEYFORGE_URL) == SAMPLE_DECK_ID
+
+    def test_raises_without_uuid(self):
+        with pytest.raises(Exception):
+            extract_deck_id('https://decksofkeyforge.com/decks/not-a-real-id')
+
+
+# --- Unit Tests for Archon Arcana List Format ---
+
+class TestArchonArcanaFormat:
+    """Test the archon_arcana list format parsing and aggregation."""
+
+    def test_aggregates_duplicates(self):
+        deck_text = '\n'.join([
+            'Gracchan_Reform',
+            'gracchan reform',
+            'Gracchan Reform',
+            'Ecto-Charge',
+        ])
+
+        collected = []
+        parse_archon_arcana(deck_text, lambda index, name, quantity: collected.append((index, name, quantity)))
+
+        assert len(collected) == 2
+        # All three Gracchan Reform spellings aggregate to a single card with quantity 3.
+        assert collected[0][1] == 'Gracchan_Reform'
+        assert collected[0][2] == 3
+        assert collected[1][1] == 'Ecto-Charge'
+        assert collected[1][2] == 1
+
+    def test_skips_blank_and_comment_lines(self):
+        deck_text = '# a comment\n\n// another comment\nEcto-Charge\n'
+
+        collected = []
+        parse_archon_arcana(deck_text, lambda index, name, quantity: collected.append((index, name, quantity)))
+
+        assert len(collected) == 1
+        assert collected[0][1] == 'Ecto-Charge'
+
+
+# --- Integration Tests for Archon Arcana ---
+
+@pytest.mark.integration
+class TestArchonArcanaResolution:
+    """Test live card resolution against Archon Arcana."""
+
+    def test_api_availability(self):
+        response = request_archonarcana(API_URL, params={
+            'action': 'opensearch',
+            'search': 'Ecto-Charge',
+            'limit': '1',
+            'namespace': '0',
+            'format': 'json',
+        })
+        assert response.status_code == 200
+
+    def test_resolve_basic_card(self):
+        title, image_url = resolve_card('Ecto-Charge')
+        assert title == 'Ecto-Charge'
+        assert 'wasabisys' in image_url
+        assert image_url.endswith('.png')
+        assert '/thumb/' not in image_url
+
+    def test_resolve_url_input(self):
+        title, _ = resolve_card('https://www.archonarcana.com/wiki/Ecto-Charge')
+        assert title == 'Ecto-Charge'
+
+    def test_resolve_ae_ligature(self):
+        assert resolve_card('AEmber Imp')[0] == '\u00c6mber Imp'
+
+    def test_resolve_apostrophe_and_case(self):
+        assert resolve_card("nature's call")[0] == 'Nature\u2019s Call'
+
+    def test_resolve_accented_card(self):
+        # "Gezdrutyo the Arcane" resolves to the accented "Gĕzdrutyŏ the Arcane".
+        title, _ = resolve_card('Gezdrutyo the Arcane')
+        assert title.endswith('the Arcane')
+
+    def test_resolve_unknown_card_raises(self):
+        with pytest.raises(Exception):
+            resolve_card('Not-A-Real-Card-Zzz-Nonexistent')
+
+
+# --- Integration Tests for Master Vault ---
+
+@pytest.mark.integration
+class TestMasterVaultAPI:
+    """Test loading a deck's card list from Master Vault."""
+
+    def test_get_deck_card_counts(self):
+        cards = get_deck_card_counts(SAMPLE_DECK_ID)
+        counts = dict(cards)
+
+        # The deck contains three copies of Gracchan Reform.
+        assert counts.get('Gracchan Reform') == 3
+
+    def test_includes_non_deck_cards(self):
+        cards = get_deck_card_counts(SAMPLE_DECK_ID)
+        total = sum(quantity for _, quantity in cards)
+
+        # 36 deck cards + 4 Prophecy (non-deck) cards. A total of 40 confirms
+        # the non-deck cards are included.
+        assert total == 40
+
+
+# --- Integration Tests for the Full Fetch Workflow ---
+
+@pytest.mark.integration
+class TestFullFetchWorkflow:
+    """Integration tests for the complete card fetching workflow."""
+
+    @pytest.fixture
+    def temp_dir(self):
+        front_dir = tempfile.mkdtemp()
+        yield front_dir
+        shutil.rmtree(front_dir)
+
+    def test_fetch_archon_arcana_list(self, temp_dir):
+        # Ecto-Charge x1 + Gracchan Reform x2 -> 3 image files.
+        deck_text = 'Ecto-Charge\nGracchan Reform\ngracchan_reform'
+
+        parse_deck(deck_text, DeckFormat.ARCHON_ARCANA, get_handle_card(temp_dir))
+
+        files = os.listdir(temp_dir)
+        assert len(files) == 3
+        for f in files:
+            assert os.path.getsize(os.path.join(temp_dir, f)) > 0
+
+    @pytest.mark.slow
+    def test_fetch_master_vault_deck(self, temp_dir):
+        parse_deck(MASTER_VAULT_URL, DeckFormat.MASTER_VAULT, get_handle_card(temp_dir))
+
+        files = os.listdir(temp_dir)
+        assert len(files) >= 1
+        for f in files:
+            assert os.path.getsize(os.path.join(temp_dir, f)) > 0

--- a/test/test_keyforge_plugin.py
+++ b/test/test_keyforge_plugin.py
@@ -9,10 +9,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from plugins.keyforge import deck_formats, mastervault
+from plugins.keyforge import archonarcana, deck_formats, mastervault
 from plugins.keyforge.archonarcana import (API_URL, entry_to_title,
-                                           extract_image_url, get_handle_card,
-                                           normalize_title,
+                                           get_handle_card, normalize_title,
+                                           query_page_image,
                                            remove_nonalphanumeric,
                                            request_archonarcana, resolve_card,
                                            translate_special_characters)
@@ -110,24 +110,106 @@ class TestRemoveNonalphanumeric:
         assert remove_nonalphanumeric('Shae \u201cCloudkicker\u201d') == 'ShaeCloudkicker'
 
 
-# --- Unit Tests for Image URL Extraction ---
+# --- Unit Tests for MediaWiki API Page/Image Lookup ---
 
-class TestExtractImageUrl:
-    """Test deriving the full-resolution image URL from page HTML."""
+class TestQueryPageImage:
+    """Test resolving a title to (canonical title, image URL) via the MediaWiki API."""
 
-    def test_derives_original_from_thumbnail(self):
-        html = (
-            '<a href="/wiki/File:939-070.png" class="image">'
-            '<img alt="Ecto-Charge" '
-            'src="https://mywikis-wiki-media.s3.us-central-1.wasabisys.com/archonarcana/thumb/939-070.png/300px-939-070.png" '
-            'width="300" height="420">'
-        )
-        assert extract_image_url(html) == (
-            'https://mywikis-wiki-media.s3.us-central-1.wasabisys.com/archonarcana/939-070.png'
-        )
+    def _fake_response(self, data: dict):
+        response = MagicMock()
+        response.json.return_value = data
+        return response
 
-    def test_returns_none_without_image(self):
-        assert extract_image_url('<p>This page has no card image.</p>') is None
+    def test_returns_title_and_image_for_existing_page(self):
+        data = {
+            'query': {
+                'pages': {
+                    '11067': {
+                        'pageid': 11067,
+                        'title': 'Ecto-Charge',
+                        'original': {'source': 'https://example.com/939-070.png'},
+                    }
+                }
+            }
+        }
+        with patch.object(archonarcana, 'request_archonarcana', return_value=self._fake_response(data)):
+            assert query_page_image('Ecto-Charge') == ('Ecto-Charge', 'https://example.com/939-070.png')
+
+    def test_returns_canonical_title_after_redirect(self):
+        # redirects=1 makes the API resolve a redirect title to its target; the
+        # page object's own title (not the query title) is the canonical one.
+        data = {
+            'query': {
+                'redirects': [{'from': 'Ecto Charge', 'to': 'Ecto-Charge'}],
+                'pages': {
+                    '11067': {
+                        'pageid': 11067,
+                        'title': 'Ecto-Charge',
+                        'original': {'source': 'https://example.com/939-070.png'},
+                    }
+                }
+            }
+        }
+        with patch.object(archonarcana, 'request_archonarcana', return_value=self._fake_response(data)):
+            assert query_page_image('Ecto Charge') == ('Ecto-Charge', 'https://example.com/939-070.png')
+
+    def test_returns_title_with_none_image_when_page_has_no_image(self):
+        data = {
+            'query': {
+                'pages': {
+                    '123': {'pageid': 123, 'title': 'Some Page'}
+                }
+            }
+        }
+        with patch.object(archonarcana, 'request_archonarcana', return_value=self._fake_response(data)):
+            assert query_page_image('Some Page') == ('Some Page', None)
+
+    def test_returns_none_for_missing_page(self):
+        data = {
+            'query': {
+                'pages': {
+                    '-1': {'title': 'Not A Real Card', 'missing': ''}
+                }
+            }
+        }
+        with patch.object(archonarcana, 'request_archonarcana', return_value=self._fake_response(data)):
+            assert query_page_image('Not A Real Card') is None
+
+
+# --- Unit Tests for Card Resolution Control Flow ---
+
+class TestResolveCard:
+    """Test resolve_card's direct-lookup/search-fallback branches without hitting the network."""
+
+    def test_direct_hit_skips_search(self):
+        with patch.object(archonarcana, 'query_page_image', return_value=('Ecto-Charge', 'https://example.com/a.png')), \
+             patch.object(archonarcana, 'search_title') as mock_search:
+            assert resolve_card('Ecto-Charge') == ('Ecto-Charge', 'https://example.com/a.png')
+            mock_search.assert_not_called()
+
+    def test_falls_back_to_search_when_direct_lookup_misses(self):
+        with patch.object(archonarcana, 'query_page_image', side_effect=[None, ('Resolved Title', 'https://example.com/b.png')]), \
+             patch.object(archonarcana, 'search_title', return_value='Resolved Title'):
+            assert resolve_card('ecto charge') == ('Resolved Title', 'https://example.com/b.png')
+
+    def test_raises_when_search_finds_nothing(self):
+        with patch.object(archonarcana, 'query_page_image', return_value=None), \
+             patch.object(archonarcana, 'search_title', return_value=None):
+            with pytest.raises(Exception, match='card not found'):
+                resolve_card('Not A Real Card')
+
+    def test_raises_when_search_result_also_misses(self):
+        with patch.object(archonarcana, 'query_page_image', return_value=None), \
+             patch.object(archonarcana, 'search_title', return_value='Resolved Title'):
+            with pytest.raises(Exception, match='card not found'):
+                resolve_card('ecto charge')
+
+    def test_raises_when_page_has_no_image(self):
+        with patch.object(archonarcana, 'query_page_image', return_value=('Some Page', None)), \
+             patch.object(archonarcana, 'search_title') as mock_search:
+            with pytest.raises(Exception, match='card image not found'):
+                resolve_card('Some Page')
+            mock_search.assert_not_called()
 
 
 # --- Unit Tests for Master Vault Deck ID Extraction ---

--- a/test/test_plugin_fetch_smoke.py
+++ b/test/test_plugin_fetch_smoke.py
@@ -26,6 +26,7 @@ PLUGINS = [
     ('flesh_and_blood', 'plugins.flesh_and_blood.fetch', ['fab']),
     ('grand_archive', 'plugins.grand_archive.fetch', ['gatcg']),
     ('gundam', 'plugins.gundam.fetch', ['gundam']),
+    ('keyforge', 'plugins.keyforge.fetch', ['archon_arcana']),
     ('lorcana', 'plugins.lorcana.fetch', ['lorcast']),
     ('lotr_lcg', 'plugins.lotr_lcg.fetch', ['ringsdb_url', 'ringsdb_fellowship_url', 'ringsdb_scenario_url', 'hallofbeorn_url']),
     ('mtg', 'plugins.mtg.fetch', ['moxfield', 'archidekt', 'text']),


### PR DESCRIPTION
Introduces a new KeyForge plugin that fetches card images from the Archon Arcana wiki, supporting both plain-text decklists and official deck URLs. The plugin handles Cloudflare-protected API calls, robust name normalization, ASCII-to-typographic character mapping, and downloads original full-resolution card art.

### Key Changes
- **CLI Entry Point (`plugins/keyforge/fetch.py`)**: Implemented a Click-based command-line interface accepting deck paths and formats (`archon_arcana` or `master_vault`).
- **Deck Parsing (`plugins/keyforge/deck_formats.py`)**: Added parsing and aggregation of duplicate cards to preserve first-seen order before starting sequential downloading.
- **Master Vault Integration (`plugins/keyforge/mastervault.py`)**: Used `cloudscraper` to query the Master Vault API and extract card lists and counts (including non-deck cards like Prophecies) using UUIDs from Master Vault or Decks of KeyForge URLs.
- **Archon Arcana Client (`plugins/keyforge/archonarcana.py`)**:
  - Resolves names/URLs to wiki pages with fallback fuzzy-matching using `SequenceMatcher`.
  - Translates ASCII to typographic characters (`AEmber` -> `Æmber`, curly quotes, typographic apostrophes) and normalizes accents and spacing.
  - Parses full-resolution image URLs from HTML thumbnail paths.
- **Comprehensive Testing (`test/test_keyforge_plugin.py`)**: Added extensive unit and integration tests for formatting, character translations, title normalization, Master Vault API queries, and end-to-end fetch workflows.
- **Documentation Sync**: Added documentation in `plugins/keyforge/README.md` and a Hugo page in `hugo/content/plugins/keyforge.md`, and updated game support tables in `README.md` and `AGENTS.md`.