### PR TITLE
Fix batch --new warning spam; calibrate improvements

### DIFF
--- a/assets/extra_layouts/README.md
+++ b/assets/extra_layouts/README.md
@@ -1,9 +1,6 @@
 # Extra Layouts
 
 Drop any number of `*.json` files here to extend `layouts.json` with additional card sizes,
-paper sizes, and layouts, without modifying this repo. Files are merged in filename order;
-see `merge_extra_layouts()` in `utilities.py` for the merge rules.
+paper sizes, and layouts.
 
-This directory is empty by default — nothing here changes behavior until you add a file. For
-an example of a project that defines its own card sizes this way, see
-[scm-extras](https://github.com/Alan-Cha/scm-extras).
+For example, see [scm-extras](https://github.com/Alan-Cha/scm-extras).

--- a/assets/gui_coordinates.json
+++ b/assets/gui_coordinates.json
@@ -1,6 +1,5 @@
 {
-  "version": "1.2.0",
-  "silhouette_studio_version": "5.0.402ss",
+  "silhouette_studio_version": "5.0.414ss",
   "window": {
     "x": 0,
     "y": 0,
@@ -11,178 +10,169 @@
     "pref_import_tab": {
       "name": "Import tab in Preferences",
       "relative": {
-        "x": 951,
-        "y": 330
+        "x": 952,
+        "y": 332
       }
     },
     "pref_dxf_open_dropdown": {
       "name": "DXF Open dropdown",
       "relative": {
-        "x": 1199,
-        "y": 452
+        "x": 1055,
+        "y": 454
       }
     },
     "pref_dxf_asis": {
       "name": "As-is option for DXF Open",
       "relative": {
-        "x": 1054,
-        "y": 486
+        "x": 1055,
+        "y": 485
       }
     },
     "pref_ok": {
       "name": "OK button in Preferences",
       "relative": {
-        "x": 1181,
+        "x": 1180,
         "y": 779
       }
     },
     "page_setup": {
       "name": "Page Setup icon in sidebar",
       "relative": {
-        "x": 1885,
-        "y": 164
+        "x": 1897,
+        "y": 124
       }
     },
     "cutting_mat_dropdown": {
       "name": "Cutting mat dropdown",
       "relative": {
-        "x": 1819,
-        "y": 362
+        "x": 1697,
+        "y": 335
       }
     },
     "cutting_mat_12x12": {
       "name": "12x12 cutting mat option",
       "relative": {
-        "x": 1675,
-        "y": 487
+        "x": 1697,
+        "y": 457
       }
     },
     "cutting_mat_12x24": {
       "name": "12x24 cutting mat option",
       "relative": {
-        "x": 1674,
-        "y": 518
+        "x": 1697,
+        "y": 488
       }
     },
     "media_size_dropdown": {
       "name": "Media size dropdown",
       "relative": {
-        "x": 1819,
-        "y": 398
+        "x": 1696,
+        "y": 376
       }
     },
     "media_size_12x12": {
       "name": "12x12 media size option",
       "relative": {
-        "x": 1668,
-        "y": 507
+        "x": 1691,
+        "y": 482
       }
     },
     "media_size_12x24": {
       "name": "12x24 media size option",
       "relative": {
-        "x": 1668,
-        "y": 507
+        "x": 1692,
+        "y": 482
       }
     },
     "media_width_field": {
       "name": "Media width input field",
       "relative": {
-        "x": 1764,
-        "y": 490
+        "x": 1790,
+        "y": 467
       }
     },
     "media_height_field": {
       "name": "Media height input field",
       "relative": {
-        "x": 1763,
-        "y": 552
+        "x": 1790,
+        "y": 529
       }
     },
     "portrait_button": {
       "name": "Portrait orientation button",
       "relative": {
-        "x": 1622,
-        "y": 625
+        "x": 1646,
+        "y": 602
       }
     },
     "landscape_button": {
       "name": "Landscape orientation button",
       "relative": {
-        "x": 1765,
-        "y": 625
+        "x": 1790,
+        "y": 600
       }
-    },
-    "constrain_media_checkbox": {
-      "name": "Constrain Media to Cutting Mat checkbox",
-      "relative": {
-        "x": 1573,
-        "y": 586
-      },
-      "unchecked_variance": 0.2,
-      "checked_variance": 2443.0
     },
     "transform": {
       "name": "Transform icon in sidebar",
       "relative": {
-        "x": 1884,
-        "y": 473
+        "x": 1897,
+        "y": 245
       }
     },
     "center_to_page": {
       "name": "Center to Page button",
       "relative": {
-        "x": 1753,
-        "y": 252
+        "x": 1777,
+        "y": 229
       }
     },
     "print_cut": {
       "name": "Print & Cut icon in sidebar",
       "relative": {
-        "x": 1885,
-        "y": 709
+        "x": 1896,
+        "y": 336
       }
     },
     "regmark_checkbox": {
       "name": "Registration marks enable checkbox",
       "relative": {
-        "x": 1571,
-        "y": 250
+        "x": 1594,
+        "y": 225
       }
     },
     "regmark_length_field": {
       "name": "Registration mark length input field",
       "relative": {
-        "x": 1757,
-        "y": 431
+        "x": 1785,
+        "y": 408
       }
     },
     "regmark_thickness_field": {
       "name": "Registration mark thickness input field",
       "relative": {
-        "x": 1757,
-        "y": 486
+        "x": 1783,
+        "y": 463
       }
     },
     "regmark_inset_field": {
       "name": "Registration mark inset input field",
       "relative": {
-        "x": 1757,
-        "y": 542
+        "x": 1785,
+        "y": 517
       }
     },
     "cutting_path_menu": {
       "name": "Cutting path right-click target",
       "relative": {
-        "x": 938,
-        "y": 506
+        "x": 1470,
+        "y": 585
       }
     },
     "context_flip_vertically": {
       "name": "Flip Vertically option in context menu",
       "relative": {
-        "x": 1001,
-        "y": 735
+        "x": 1557,
+        "y": 316
       }
     }
   },

--- a/dxf_to_studio3.py
+++ b/dxf_to_studio3.py
@@ -38,7 +38,7 @@ import platform
 import click
 
 from enums import Orientation, Variant, Unit
-from utilities import load_layout_config, get_all_paper_size_names, resolve_paper_size_alias, LayoutConfig, template_name, resolve_cutting_templates_dir, BORDERLESS_EXPANSION_MM
+from utilities import load_layout_config, get_all_paper_size_names, resolve_paper_size_alias, LayoutConfig, resolve_cutting_templates_dir, BORDERLESS_EXPANSION_MM
 import size_convert
 import page_manager
 
@@ -1141,26 +1141,22 @@ def batch(unit, studio_path, action_delay, calibration_path, generate_new, dry_r
     config = load_layout_config()
 
     if generate_new:
-        # Derive expected DXF/studio3 filenames from layouts.json
+        # Only DXFs that actually exist in out_path are candidates - out_path may only
+        # contain a subset of layouts.json's full catalog (e.g. when
+        # SCM_CUTTING_TEMPLATES_DIR is redirected to a companion project's own card
+        # sizes), so deriving candidates from layouts.json itself (like the old
+        # implementation did) would warn about every entry that will never exist there.
+        # Among the DXFs that do exist, skip ones whose .studio3 is already converted.
+        all_dxf_files = sorted(list((out_path / "dxf").glob("*.dxf")) + list((out_path / "borderless" / "dxf").glob("*.dxf")))
         dxf_files = []
-        for ps, cards in config.layouts.items():
-            for cs, variants in cards.items():
-                for var_str, layout_def in variants.items():
-                    var = Variant(var_str)
-                    name = template_name(ps, cs, var, layout_def.version)
-                    # Borderless templates go in borderless/ subdirectory
-                    if var == Variant.BORDERLESS:
-                        studio3_file = out_path / "borderless" / f"{name}.studio3"
-                        dxf_file = out_path / "borderless" / "dxf" / f"{name}.dxf"
-                    else:
-                        studio3_file = out_path / f"{name}.studio3"
-                        dxf_file = out_path / "dxf" / f"{name}.dxf"
-                    if not studio3_file.exists():
-                        if dxf_file.exists():
-                            dxf_files.append(dxf_file)
-                        else:
-                            click.echo(f"  Warning: missing DXF {dxf_file.name} for {ps} + {cs} + {var}")
-        dxf_files.sort()
+        for dxf_file in all_dxf_files:
+            _, _, variant = parse_dxf_filename(dxf_file.name, config) or (None, None, None)
+            if variant == Variant.BORDERLESS:
+                studio3_file = out_path / "borderless" / dxf_file.with_suffix(".studio3").name
+            else:
+                studio3_file = out_path / dxf_file.with_suffix(".studio3").name
+            if not studio3_file.exists():
+                dxf_files.append(dxf_file)
     else:
         # Search both default and borderless DXF directories
         dxf_files = sorted(list((out_path / "dxf").glob("*.dxf")) + list((out_path / "borderless" / "dxf").glob("*.dxf")))

--- a/dxf_to_studio3.py
+++ b/dxf_to_studio3.py
@@ -757,8 +757,8 @@ CALIBRATION_ELEMENTS = [
     {
         "id": "cutting_mat_12x24",
         "name": "12x24 cutting mat option",
-        "description": "Open the cutting mat dropdown again and "
-                       "click the 12\" x 24\" option."
+        "description": "The cutting mat dropdown should be open. "
+                       "Click the 12\" x 24\" option."
     },
     {
         "id": "media_size_dropdown",
@@ -768,85 +768,89 @@ CALIBRATION_ELEMENTS = [
     {
         "id": "media_size_12x12",
         "name": "12x12 media size option",
-        "description": "The 12x12 cutting mat must be selected and the media size dropdown must be open. "
+        "description": "The 12x12 cutting mat must be selected and the media size dropdown should be open. "
                        "Click the 12\" x 12\" option."
     },
     {
         "id": "media_size_12x24",
         "name": "12x24 media size option",
-        "description": "Select the 12x24 cutting mat first, then open the media size dropdown again and "
-                       "click the 12\" x 24\" option."
+        "description": "The 12x24 cutting mat must be selected and the media size dropdown should be open. "
+                       "Click the 12\" x 24\" option."
     },
     {
         "id": "media_width_field",
         "name": "Media width input field",
-        "description": "The numerical input field for custom media width."
+        "description": "Click the numerical input field for custom media width."
     },
     {
         "id": "media_height_field",
         "name": "Media height input field",
-        "description": "The numerical input field for custom media height."
+        "description": "Click the numerical input field for custom media height."
     },
     {
         "id": "portrait_button",
         "name": "Portrait orientation button",
-        "description": "Scroll down if needed to find the orientation buttons."
+        "description": "Click the portrait orientation button."
     },
     {
         "id": "landscape_button",
         "name": "Landscape orientation button",
-        "description": "Next to the Portrait button"
+        "description": "Click the landscape orientation button."
     },
     # --- Transform ---
     {
         "id": "transform",
         "name": "Transform icon in sidebar",
-        "description": "Click the Transform tool icon in the left sidebar"
+        "description": "Click the Transform panel icon in the left sidebar"
     },
     {
         "id": "center_to_page",
         "name": "Center to Page button",
-        "description": "The Transform panel should now be open. "
-                       "Find the Center to Page button."
+        "description": "The Transform panel should be open. "
+                       "Click the Center to Page button."
     },
     # --- Print & Cut ---
     {
         "id": "print_cut",
         "name": "Print & Cut icon in sidebar",
-        "description": "Click the Print & Cut (registration marks) tool icon in the left sidebar"
+        "description": "Click the Print & Cut (registration marks) panel icon in the left sidebar"
     },
     {
         "id": "regmark_checkbox",
         "name": "Registration marks enable checkbox",
-        "description": "The Print & Cut panel should now be open. "
-                       "Find the checkbox to enable registration marks."
+        "description": "The Print & Cut panel should be open. "
+                       "Click the checkbox to enable registration marks."
     },
     {
         "id": "regmark_length_field",
         "name": "Registration mark length input field",
-        "description": "The numerical input field for mark length"
+        "description": "The Print & Cut panel should be open. "
+                       "Click the numerical input field for mark length"
     },
     {
         "id": "regmark_thickness_field",
         "name": "Registration mark thickness input field",
-        "description": "The numerical input field for mark thickness"
+        "description": "The Print & Cut panel should be open. "
+                       "Click the numerical input field for mark thickness"
     },
     {
         "id": "regmark_inset_field",
         "name": "Registration mark inset input field",
-        "description": "The numerical input field for mark inset"
+        "description": "The Print & Cut panel should be open. "
+                       "Click the numerical input field for mark inset"
     },
     # --- Flip Vertically (right-click context menu) ---
     {
         "id": "cutting_path_menu",
-        "name": "Cutting path right-click target",
-        "description": "Click on any cutting path on the canvas "
+        "name": "Open cutting path menu (right-click)",
+        "description": "Select on any cutting path on the canvas "
                        "(used as the target for the right-click context menu)."
+                       "Right click anywhere to open the context menu."
     },
     {
         "id": "context_flip_vertically",
         "name": "Flip Vertically option in context menu",
-        "description": "Right-click a cutting path to open the context menu. "
+        "description": "The cutting path context menu should be open. "
                        "Click the 'Flip Vertically' option."
     },
 ]
@@ -1079,14 +1083,25 @@ def calibrate(studio_path):
     }
 
     try:
-        for element in CALIBRATION_ELEMENTS:
+        index = 0
+        while index < len(CALIBRATION_ELEMENTS):
+            element = CALIBRATION_ELEMENTS[index]
             click.echo(f"\n--- {element['name']} ---")
             click.echo(f"    {element['description']}")
 
-            response = input("Position mouse and press Enter (or 's' to skip): ").strip().lower()
+            response = input("Position mouse and press Enter (or 's' to skip, 'b' to go back): ").strip().lower()
+
+            if response == 'b':
+                if index == 0:
+                    click.echo("  Already at the first element.")
+                else:
+                    index -= 1
+                    click.echo("  Going back...")
+                continue
 
             if response == 's':
                 click.echo("  Skipped")
+                index += 1
                 continue
 
             pos = pyautogui.position()
@@ -1101,6 +1116,7 @@ def calibrate(studio_path):
             }
 
             click.echo(f"  Recorded: relative=({rel_x}, {rel_y})")
+            index += 1
 
     except KeyboardInterrupt:
         click.echo("\n\nCalibration interrupted.")

--- a/dxf_to_studio3.py
+++ b/dxf_to_studio3.py
@@ -1185,8 +1185,6 @@ def batch(unit, studio_path, action_delay, calibration_path, generate_new, dry_r
         return
 
     click.echo(f"Found {len(dxf_files)} DXF files to convert")
-    click.echo(f"Registration mark unit: {unit.value}")
-    click.echo()
 
     if dry_run:
         for dxf_file in dxf_files:
@@ -1207,11 +1205,15 @@ def batch(unit, studio_path, action_delay, calibration_path, generate_new, dry_r
             len_str = f", max_length={max_len}{unit.value}" if max_len is not None else ""
             click.echo(f"  {dxf_file.name} -> {output_file.name} ({orientation.value}, {paper_w} x {paper_h}{len_str})")
         click.echo()
+        click.echo(f"Registration mark unit: {unit.value}")
+        click.echo()
         click.echo("Dry run complete. No files were converted.")
         return
 
     for dxf_file in dxf_files:
         click.echo(f"  {dxf_file.name}")
+    click.echo()
+    click.echo(f"Registration mark unit: {unit.value}")
     click.echo()
 
     click.echo("=" * 60)

--- a/dxf_to_studio3.py
+++ b/dxf_to_studio3.py
@@ -1185,7 +1185,7 @@ def batch(unit, studio_path, action_delay, calibration_path, generate_new, dry_r
         return
 
     click.echo(f"Found {len(dxf_files)} DXF files to convert")
-    click.echo(f"Registration mark unit: {unit}")
+    click.echo(f"Registration mark unit: {unit.value}")
     click.echo()
 
     if dry_run:
@@ -1204,11 +1204,15 @@ def batch(unit, studio_path, action_delay, calibration_path, generate_new, dry_r
                 paper_w, paper_h = adjust_paper_for_borderless(paper_w, paper_h)
 
             max_len = get_max_length_for_dxf(paper_size, card_size, variant, config, unit)
-            len_str = f", max_length={max_len}{unit}" if max_len is not None else ""
+            len_str = f", max_length={max_len}{unit.value}" if max_len is not None else ""
             click.echo(f"  {dxf_file.name} -> {output_file.name} ({orientation.value}, {paper_w} x {paper_h}{len_str})")
         click.echo()
         click.echo("Dry run complete. No files were converted.")
         return
+
+    for dxf_file in dxf_files:
+        click.echo(f"  {dxf_file.name}")
+    click.echo()
 
     click.echo("=" * 60)
     click.echo("Batch DXF to Studio3 Converter")


### PR DESCRIPTION
## Summary
- `dxf_to_studio3.py batch --new` derived its candidate list from the full merged `layouts.json` catalog, so once `SCM_CUTTING_TEMPLATES_DIR` redirects output to a directory scoped to only some card sizes (e.g. a companion project's own extras), it printed a "missing DXF" warning for every entry that will never exist there. It now derives candidates from the DXF files actually present in `TEMPLATES_DIR`, skipping ones whose `.studio3` already exists.
- `calibrate` prompts are clarified to state actionable steps, and the command now supports stepping backward with `b` if a coordinate was recorded incorrectly.
- `gui_coordinates.json` updated with fresh coordinates for Silhouette Studio 5.0.414ss.

## Test plan
- [x] `pytest test/test_utilities.py` passes (111 tests)
- [x] `dxf_to_studio3.py batch --new --dry_run` against a `SCM_CUTTING_TEMPLATES_DIR` scoped to only a subset of card sizes no longer prints spurious warnings, and correctly lists only the files still needing conversion