### PR TITLE
Document LINE+ARC rejection, fix calibrate data loss on skip

### DIFF
--- a/dxf_manager.py
+++ b/dxf_manager.py
@@ -11,28 +11,22 @@ ezdxf.options.write_fixed_meta_data_for_testing = True
 def add_rounded_rectangle(msp, x, y, width, height, radius):
     """Add a rounded rectangle as a single closed LWPOLYLINE with bulge factors.
 
-    Uses LWPOLYLINE with bulge-encoded arcs so Silhouette Studio sees one
-    connected path and renders smooth line-to-arc transitions.
+    Uses LWPOLYLINE with bulge-encoded arcs for smooth line-to-arc joins.
 
-    LINE + ARC entities (tried instead, twice) were rejected both times:
-    - Loose LINE/ARC entities in modelspace get merged by SS into a single
-      compound path across all cards in the file, making individual cards
-      unselectable after import.
-    - Wrapping the LINE+ARC shape in a block and placing each card via an
-      INSERT avoids that merge (each INSERT is one selectable object), but
-      SS then renders the line-to-arc joins with a visible sharp corner on
-      one side of each arc instead of a smooth transition. Verified on SS
-      5.0.414ss. This alone rules out LINE+ARC regardless of the
-      selectability fix, since a sharp corner artifact on the cutting path
-      isn't acceptable.
+    LINE+ARC entities were tried instead but rejected: SS renders a sharp
+    corner where line meets arc instead of a smooth join. (LINE+ARC also
+    merges multiple cards into one compound path, but Release Compound Path
+    fixes that — the sharp corner is the actual blocker.)
 
-    NOTE: SS vertically mirrors image fills for closed-polyline entities
-    (LINE+ARC does not have this problem, but can't be used — see above).
-    dxf_to_studio3.py's flip_vertically() step corrects the fill by flipping
-    the whole imported object, which also mirrors the cutting path itself.
-    That's accepted here because generate_dxf() only supports a single
-    uniform corner radius, so every card shape is vertically symmetric and
-    mirroring it has no visible effect on the cut.
+    SS imports polyline paths at the coordinates as authored — confirmed by
+    manually opening a DXF in SS with no automation involved, the path is
+    never mirrored — but mirrors the image fill. flip_vertically() in
+    dxf_to_studio3.py fixes the fill by mirroring the whole object, which
+    mirrors the path too — a single combined flip, not two separate fixes.
+    Harmless today since generate_dxf() only emits a single uniform corner
+    radius (symmetric shapes); if per-corner radii are ever added, check
+    against the printed card art which orientation is actually correct
+    rather than assuming.
 
     Bulge factor for a 90° CCW arc = tan(22.5°) ≈ 0.4142.
     Positive bulge = CCW arc (left of travel direction).

--- a/dxf_manager.py
+++ b/dxf_manager.py
@@ -14,8 +14,25 @@ def add_rounded_rectangle(msp, x, y, width, height, radius):
     Uses LWPOLYLINE with bulge-encoded arcs so Silhouette Studio sees one
     connected path and renders smooth line-to-arc transitions.
 
-    NOTE: SS vertically flips image fills for closed polyline entities. These
-    DXF files are cutting templates only, so fill orientation is irrelevant.
+    LINE + ARC entities (tried instead, twice) were rejected both times:
+    - Loose LINE/ARC entities in modelspace get merged by SS into a single
+      compound path across all cards in the file, making individual cards
+      unselectable after import.
+    - Wrapping the LINE+ARC shape in a block and placing each card via an
+      INSERT avoids that merge (each INSERT is one selectable object), but
+      SS then renders the line-to-arc joins with a visible sharp corner on
+      one side of each arc instead of a smooth transition. Verified on SS
+      5.0.414ss. This alone rules out LINE+ARC regardless of the
+      selectability fix, since a sharp corner artifact on the cutting path
+      isn't acceptable.
+
+    NOTE: SS vertically mirrors image fills for closed-polyline entities
+    (LINE+ARC does not have this problem, but can't be used — see above).
+    dxf_to_studio3.py's flip_vertically() step corrects the fill by flipping
+    the whole imported object, which also mirrors the cutting path itself.
+    That's accepted here because generate_dxf() only supports a single
+    uniform corner radius, so every card shape is vertically symmetric and
+    mirroring it has no visible effect on the cut.
 
     Bulge factor for a 90° CCW arc = tan(22.5°) ≈ 0.4142.
     Positive bulge = CCW arc (left of travel direction).

--- a/dxf_to_studio3.py
+++ b/dxf_to_studio3.py
@@ -573,12 +573,10 @@ class SilhouetteAutomation:
     def flip_vertically(self):
         """Select all objects and flip them vertically via the right-click context menu.
 
-        Corrects the image-fill mirroring SS applies to closed-polyline cutting
-        shapes (see add_rounded_rectangle() in dxf_manager.py for why LINE+ARC
-        entities, which don't have this fill-mirroring problem, can't be used
-        instead). This also mirrors the cutting path itself, which is fine
-        since generate_dxf() only produces vertically-symmetric card shapes
-        (single uniform corner radius).
+        Corrects SS's image-fill mirroring on closed-polyline shapes (see
+        add_rounded_rectangle() in dxf_manager.py). Also mirrors the cutting
+        path, harmless today since shapes are symmetric (single uniform
+        corner radius).
         """
         print("  Flipping vertically...")
         pyautogui.hotkey('ctrl', 'a')

--- a/dxf_to_studio3.py
+++ b/dxf_to_studio3.py
@@ -573,9 +573,12 @@ class SilhouetteAutomation:
     def flip_vertically(self):
         """Select all objects and flip them vertically via the right-click context menu.
 
-        DXF files are imported by Silhouette Studio with a vertical flip. This corrects
-        the orientation by selecting all objects and applying Flip Vertically through
-        the cutting path right-click context menu.
+        Corrects the image-fill mirroring SS applies to closed-polyline cutting
+        shapes (see add_rounded_rectangle() in dxf_manager.py for why LINE+ARC
+        entities, which don't have this fill-mirroring problem, can't be used
+        instead). This also mirrors the cutting path itself, which is fine
+        since generate_dxf() only produces vertically-symmetric card shapes
+        (single uniform corner radius).
         """
         print("  Flipping vertically...")
         pyautogui.hotkey('ctrl', 'a')
@@ -646,7 +649,7 @@ class SilhouetteAutomation:
         1. Open DXF
         2. Page setup (cutting mat, media size, orientation, dimensions)
         3. Center paths
-        4. Flip vertically (corrects vertical flip from DXF import)
+        4. Flip vertically (corrects the image-fill mirror on closed-polyline shapes)
         5. Set registration marks
         6. Save as .studio3
 
@@ -692,8 +695,6 @@ class SilhouetteAutomation:
         if center:
             self.center_to_page()
 
-        # DXF files are imported into Silhouette Studio with a vertical flip.
-        # Flip vertically after centering to correct the orientation.
         self.flip_vertically()
 
         if registration:
@@ -1067,18 +1068,26 @@ def calibrate(studio_path):
     # Start Silhouette Studio at fixed size
     _, window_rect = start_and_resize_studio(studio_path)
 
+    output_file = CALIBRATION_FILE
+    existing = load_calibration(output_file)
+    existing_elements = existing.get("elements", {}) if existing else {}
+
     click.echo()
-    version = click.prompt("What version of Silhouette Studio are you using?", default="unknown")
+    version = click.prompt(
+        "What version of Silhouette Studio are you using?",
+        default=existing.get("silhouette_studio_version", "unknown") if existing else "unknown"
+    )
     click.echo()
 
-    output_file = CALIBRATION_FILE
     click.echo(f"Calibration will be saved to: {output_file}")
+    if existing_elements:
+        click.echo(f"Loaded {len(existing_elements)} existing element(s); skipped elements keep their current coordinates.")
     click.echo()
 
     calibration = {
         "silhouette_studio_version": version,
         "window": window_rect,
-        "elements": {},
+        "elements": dict(existing_elements),
         "notes": "All coordinates are relative to the window top-left corner"
     }
 
@@ -1100,7 +1109,10 @@ def calibrate(studio_path):
                 continue
 
             if response == 's':
-                click.echo("  Skipped")
+                if element["id"] in calibration["elements"]:
+                    click.echo("  Skipped (kept existing coordinates)")
+                else:
+                    click.echo("  Skipped")
                 index += 1
                 continue
 


### PR DESCRIPTION
## Summary
- Re-verified on SS 5.0.414ss that `flip_vertically()` is still needed to correct SS's image-fill mirroring on closed-polyline cutting shapes.
- Re-tried LINE+ARC entities (with a block+INSERT wrapper to preserve per-card selectability) as a way to avoid the fill mirroring, but SS renders a visible sharp corner on one side of each arc instead of a smooth join — documented this in `add_rounded_rectangle()` so it isn't re-tried blind.
- Fixed `calibrate`: skipping an element used to leave it out of the saved calibration entirely rather than keeping its existing coordinates, which would silently wipe out unrelated elements if you only meant to re-record a couple.

## Test plan
- [x] Verified `dxf_manager.py` and `dxf_to_studio3.py` still parse and import cleanly.
- [x] Manually converted test DXFs through `dxf_to_studio3.py single` in Silhouette Studio 5.0.414ss and confirmed the sharp-corner join issue with LINE+ARC and the fill-mirroring behavior with polyline.
- [ ] Recalibrate `cutting_path_menu`/`context_flip_vertically` and confirm `flip_vertically()` corrects the image fill end-to-end.