### PR TITLE
Improve error handling in parse_url deck import

### DIFF
--- a/plugins/mtg/deck_formats.py
+++ b/plugins/mtg/deck_formats.py
@@ -8,8 +8,6 @@ from enum import Enum
 from typing import Callable, Tuple
 from xml.etree import ElementTree as ET
 
-from pyparsing import line
-
 from plugins.mtg.patterns import DECKSTATS_PATTERN, MOXFIELD_PATTERN
 
 import cloudscraper
@@ -405,14 +403,39 @@ def parse_cubecobra_csv(deck_text, handle_card: Callable, front_img_dir: str, do
 #     MTGJSON, Scryfall, Tapped Out, TCGPlayer
 def parse_url(deck_url, handle_card: Callable) -> None:
     scraper = cloudscraper.create_scraper()
-    cards = mtg_parser.parse_deck(deck_url, scraper)
+    try:
+        cards = mtg_parser.parse_deck(deck_url, scraper)
+    except Exception as e:
+        print(f"Error while fetching deck from URL: {deck_url} ({e})")
+        return
+
     if not cards:
-        print(f"Failed to parse deck from URL: {deck_url}")
+        # mtg_parser returns None when no parser recognizes the URL (unsupported
+        # site or malformed link), as opposed to a recognized site failing to fetch.
+        print(f"URL not recognized by any supported site: {deck_url}")
         return
 
     error_lines = []
+    card_iter = iter(cards)
+    index = 0
 
-    for index, card in enumerate(cards, start=1):
+    while True:
+        try:
+            card = next(card_iter)
+        except StopIteration:
+            break
+        except Exception as e:
+            # mtg_parser lazily fetches/parses per card, so a site-side issue
+            # (deck deleted, made private, malformed API response, etc.) only
+            # surfaces here, mid-iteration, rather than when parse_deck() is called.
+            print(
+                f"Failed to parse deck from URL: {deck_url}. "
+                f"The deck may be private, deleted, or the URL may be incorrect. "
+                f"(underlying error: {e!r})"
+            )
+            break
+
+        index += 1
         name = card.name
         set_code = card.extension
         collector_number = card.number
@@ -427,7 +450,7 @@ def parse_url(deck_url, handle_card: Callable) -> None:
             handle_card(index, name, set_code, collector_number, quantity)
         except Exception as e:
             print(f'Error: {e}')
-            error_lines.append((line, e))
+            error_lines.append((name, e))
 
     if len(error_lines) > 0:
         print(f'Errors: {error_lines}')


### PR DESCRIPTION
## Summary
- `parse_url` (URL Auto-Import) used to crash with a raw, confusing traceback (e.g. `KeyError: 'categories'`) when a recognized site failed to serve a deck — for example an Archidekt deck that's been deleted or made private, which `mtg_parser` only discovers lazily while iterating cards.
- Distinguishes two previously-identical messages: a URL no supported site recognizes vs. a recognized site that fails while fetching/parsing.
- Fixes `error_lines.append((line, e))`, which was silently recording the unrelated `pyparsing.line` import instead of the failed card's name, making per-card error reports useless.

## Test plan
- [x] Reproduced the original crash against a real deleted/private Archidekt deck URL and confirmed it now prints a clear message instead of a traceback.
- [x] Unit-tested the happy path and a mid-iteration failure with a mocked `mtg_parser.parse_deck` (list of fake cards, one `handle_card` failure, then a raised exception) to confirm normal cards still process, per-card errors record the correct name, and the loop exits cleanly on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)