### PR TITLE
Use full game title in Arkham Horror docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The [Yu-Gi-Oh! plugin](plugins/yugioh/README.md) supports **YDK** and **YDKE** f
 
 The [Altered plugin](plugins/altered/README.md) supports **Ajordat** format.
 
-The [Arkham Horror LCG plugin](plugins/arkham_horror_lcg/README.md) supports **ArkhamDB** format.
+The [Arkham Horror: The Card Game plugin](plugins/arkham_horror_lcg/README.md) supports **ArkhamDB** format.
 
 The [Ashes Reborn plugin](plugins/ashes_reborn/README.md) supports **Ashes** and **Ashes DB** formats.
 

--- a/hugo/content/plugins/_index.md
+++ b/hugo/content/plugins/_index.md
@@ -12,7 +12,7 @@ The following plugins are currently available:
 * [Pokemon](pokemon)
 * [Yu-Gi-Oh!](yugioh)
 * [Altered](altered)
-* [Arkham Horror LCG](arkham_horror_lcg)
+* [Arkham Horror: The Card Game](arkham_horror_lcg)
 * [Ashes Reborn](ashes_reborn)
 * [Bushiroad](bushiroad)
 * [Digimon](digimon)

--- a/hugo/content/plugins/arkham_horror_lcg.md
+++ b/hugo/content/plugins/arkham_horror_lcg.md
@@ -1,5 +1,5 @@
 ---
-title: 'Arkham Horror LCG'
+title: 'Arkham Horror: The Card Game'
 weight: 22
 ---
 

--- a/plugins/arkham_horror_lcg/README.md
+++ b/plugins/arkham_horror_lcg/README.md
@@ -1,4 +1,4 @@
-# Arkham Horror LCG Plugin
+# Arkham Horror: The Card Game Plugin
 
 This plugin reads a decklist, automatically fetches card art from [ArkhamDB](https://arkhamdb.com/) and puts them in the proper `game/` directories.
 

--- a/test/test_arkham_horror_lcg_plugin.py
+++ b/test/test_arkham_horror_lcg_plugin.py
@@ -1,5 +1,5 @@
 """
-Tests for the Arkham Horror LCG plugin.
+Tests for the Arkham Horror: The Card Game plugin.
 Tests deck format parsing and image fetching from ArkhamDB.
 """
 import json


### PR DESCRIPTION
## Summary
- The official published name of the game is *Arkham Horror: The Card Game* (a Living Card Game by Fantasy Flight Games); "Arkham Horror LCG" is a common community shorthand, not the box title.
- Updates user-facing documentation to reference the full official title, while leaving the `arkham_horror_lcg` plugin directory/module name unchanged (consistent with the repo's existing shorthand convention, e.g. `lotr_lcg`).

## Changes
- `README.md`: plugin list entry
- `plugins/arkham_horror_lcg/README.md`: heading
- `hugo/content/plugins/arkham_horror_lcg.md`: page title
- `hugo/content/plugins/_index.md`: plugin list entry
- `test/test_arkham_horror_lcg_plugin.py`: module docstring

## Test plan
- [x] Docs-only change; no code behavior affected
- [x] Verified diff is scoped to game-name references only