### PR TITLE
Update Netrunner plugin API host

### DIFF
--- a/plugins/altered/fetch.py
+++ b/plugins/altered/fetch.py
@@ -8,7 +8,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.altered.deck_formats import DeckFormat, parse_deck
 from plugins.altered.altered import get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = path.join(REPO_ROOT, 'game', 'front')
 
@@ -28,4 +28,5 @@ def cli(deck_path: str, format: DeckFormat):
         parse_deck(deck_text, format, get_handle_card(front_directory))
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/arkham_horror_lcg/fetch.py
+++ b/plugins/arkham_horror_lcg/fetch.py
@@ -9,7 +9,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.arkham_horror_lcg.deck_formats import DeckFormat, parse_deck
 from plugins.arkham_horror_lcg.api import get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = os.path.join(REPO_ROOT, 'game', 'front')
 double_sided_directory = os.path.join(REPO_ROOT, 'game', 'double_sided')
@@ -42,4 +42,5 @@ def cli(deck_path: str, format: DeckFormat):
     )
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/ashes_reborn/fetch.py
+++ b/plugins/ashes_reborn/fetch.py
@@ -8,7 +8,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.ashes_reborn.deck_formats import DeckFormat, parse_deck
 from plugins.ashes_reborn.ashes import get_handle_card, ImageServer
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = path.join(REPO_ROOT, 'game', 'front')
 
@@ -32,4 +32,5 @@ def cli(deck_path: str, format: DeckFormat, source: ImageServer):
     )
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/bushiroad/fetch.py
+++ b/plugins/bushiroad/fetch.py
@@ -8,7 +8,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.bushiroad.deck_formats import DeckFormat, parse_deck
 from plugins.bushiroad.bushiroad import get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = path.join(REPO_ROOT, 'game', 'front')
 back_directory = path.join(REPO_ROOT, 'game', 'double_sided')
@@ -34,4 +34,5 @@ def cli(deck_path: str, format: DeckFormat):
     )
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/digimon/fetch.py
+++ b/plugins/digimon/fetch.py
@@ -8,7 +8,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.digimon.deck_formats import DeckFormat, parse_deck
 from plugins.digimon.digimoncard import get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = path.join(REPO_ROOT, 'game', 'front')
 double_sided_directory = path.join(REPO_ROOT, 'game', 'double_sided')
@@ -36,4 +36,5 @@ def cli(deck_path: str, format: DeckFormat):
         )
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/echoes_of_astra/fetch.py
+++ b/plugins/echoes_of_astra/fetch.py
@@ -8,7 +8,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.echoes_of_astra.deck_formats import DeckFormat, parse_deck
 from plugins.echoes_of_astra.api import get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = path.join(REPO_ROOT, 'game', 'front')
 
@@ -25,4 +25,5 @@ def cli(deck_path: str, format: DeckFormat):
     parse_deck(deck_path, format, get_handle_card(front_directory))
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/elestrals/fetch.py
+++ b/plugins/elestrals/fetch.py
@@ -8,7 +8,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.elestrals.deck_formats import DeckFormat, parse_deck
 from plugins.elestrals.elestrals import get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = path.join(REPO_ROOT, 'game', 'front')
 
@@ -31,4 +31,5 @@ def cli(deck_path: str, format: DeckFormat):
     )
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/final_fantasy/fetch.py
+++ b/plugins/final_fantasy/fetch.py
@@ -8,7 +8,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.final_fantasy.deck_formats import DeckFormat, parse_deck
 from plugins.final_fantasy.fftcg import get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = path.join(REPO_ROOT, 'game', 'front')
 
@@ -28,4 +28,5 @@ def cli(deck_path: str, format: DeckFormat):
         parse_deck(deck_text, format, get_handle_card(front_directory))
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/flesh_and_blood/fetch.py
+++ b/plugins/flesh_and_blood/fetch.py
@@ -8,7 +8,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.flesh_and_blood.deck_formats import DeckFormat, parse_deck
 from plugins.flesh_and_blood.fabtcg import get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = path.join(REPO_ROOT, 'game', 'front')
 double_sided_directory = path.join(REPO_ROOT, 'game', 'double_sided')
@@ -30,4 +30,5 @@ def cli(deck_path: str, format: DeckFormat):
         parse_deck(deck_text, format, get_handle_card(front_directory))
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/grand_archive/fetch.py
+++ b/plugins/grand_archive/fetch.py
@@ -8,7 +8,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.grand_archive.deck_formats import DeckFormat, parse_deck
 from plugins.grand_archive.gatcg import get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = path.join(REPO_ROOT, 'game', 'front')
 double_sided_directory = path.join(REPO_ROOT, 'game', 'double_sided')
@@ -30,4 +30,5 @@ def cli(deck_path: str, format: DeckFormat):
         parse_deck(deck_text, format, get_handle_card( front_directory ))
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/gundam/fetch.py
+++ b/plugins/gundam/fetch.py
@@ -8,7 +8,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.gundam.deck_formats import DeckFormat, parse_deck
 from plugins.gundam.gundam import get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = path.join(REPO_ROOT, 'game', 'front')
 double_sided_directory = path.join(REPO_ROOT, 'game', 'double_sided')
@@ -30,4 +30,5 @@ def cli(deck_path: str, format: DeckFormat):
         parse_deck(deck_text, format, get_handle_card(front_directory))
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/lorcana/fetch.py
+++ b/plugins/lorcana/fetch.py
@@ -9,7 +9,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.lorcana.deck_formats import DeckFormat, parse_deck
 from plugins.lorcana.lorcast import get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = os.path.join(REPO_ROOT, 'game', 'front')
 
@@ -38,4 +38,5 @@ def cli(
         )
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/lotr_lcg/fetch.py
+++ b/plugins/lotr_lcg/fetch.py
@@ -10,7 +10,7 @@ sys.path.insert(0, REPO_ROOT)
 from plugins.lotr_lcg.deck_formats import DeckFormat, parse_deck
 from plugins.lotr_lcg.hallofbeorn import ScenarioMode
 from plugins.lotr_lcg.ringsdb import get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = path.join(REPO_ROOT, "game", "front")
 double_sided_directory = path.join(REPO_ROOT, "game", "double_sided")
@@ -38,5 +38,6 @@ def cli(deck_path: str, format: DeckFormat, scenario_mode: str):
     )
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/mtg/deck_formats.py
+++ b/plugins/mtg/deck_formats.py
@@ -11,11 +11,11 @@ from xml.etree import ElementTree as ET
 from plugins.mtg.patterns import DECKSTATS_PATTERN, MOXFIELD_PATTERN
 
 import cloudscraper
-import filetype
 import mtg_parser
 import requests
 
 from plugins.mtg.common import remove_nonalphanumeric
+from utilities import guess_extension
 
 card_data_tuple = Tuple[str, str, int, int]
 
@@ -370,8 +370,7 @@ def parse_cubecobra_csv(deck_text, handle_card: Callable, front_img_dir: str, do
                 clean_name = remove_nonalphanumeric(name)
                 response = requests.get(image_url, headers={'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
                 response.raise_for_status()
-                kind = filetype.guess(response.content)
-                ext = f'.{kind.extension}' if kind else '.png'
+                ext = guess_extension(response.content)
                 for counter in range(quantity):
                     image_path = os.path.join(front_img_dir, f'{str(index)}{clean_name}{str(counter + 1)}{ext}')
                     with open(image_path, 'wb') as f:
@@ -381,8 +380,7 @@ def parse_cubecobra_csv(deck_text, handle_card: Callable, front_img_dir: str, do
                     print(f'Fetching back image from URL: {image_back_url}')
                     back_response = requests.get(image_back_url, headers={'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
                     back_response.raise_for_status()
-                    back_kind = filetype.guess(back_response.content)
-                    back_ext = f'.{back_kind.extension}' if back_kind else '.png'
+                    back_ext = guess_extension(back_response.content)
                     for counter in range(quantity):
                         image_path = os.path.join(double_sided_dir, f'{str(index)}{clean_name}{str(counter + 1)}{back_ext}')
                         with open(image_path, 'wb') as f:

--- a/plugins/mtg/fetch.py
+++ b/plugins/mtg/fetch.py
@@ -11,7 +11,7 @@ from plugins.mtg.common import ScryfallLanguage
 from plugins.mtg.deck_formats import DeckFormat, parse_deck, extract_mpcfill_card_ids
 from plugins.mtg.scryfall import get_handle_card as scryfall_get_handle_card
 from plugins.mtg.mpcfill import get_handle_card as mpc_get_handle_card, prefetch_mpcfill
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = os.path.join(REPO_ROOT, 'game', 'front')
 double_sided_directory = os.path.join(REPO_ROOT, 'game', 'double_sided')
@@ -96,4 +96,5 @@ def cli(
     )
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/mtg/mpcfill.py
+++ b/plugins/mtg/mpcfill.py
@@ -23,9 +23,9 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Set
 
 import requests
-from filetype.filetype import guess_extension
 
 from .common import remove_nonalphanumeric
+from utilities import guess_extension
 
 session = requests.Session()
 
@@ -115,8 +115,8 @@ def write_slot_image(
         return
 
     clean_name = remove_nonalphanumeric(name)
-    card_art_ext = guess_extension(card_art)
-    image_path = os.path.join(output_dir, f'{slot}{clean_name}.{card_art_ext}')
+    extension = guess_extension(card_art)
+    image_path = os.path.join(output_dir, f'{slot}{clean_name}{extension}')
 
     with open(image_path, 'wb') as f:
         f.write(card_art)

--- a/plugins/netrunner/api.py
+++ b/plugins/netrunner/api.py
@@ -4,7 +4,7 @@ from time import sleep
 from re import sub
 from unicodedata import normalize, category
 
-import filetype
+from utilities import guess_extension
 
 session = Session()
 
@@ -45,18 +45,19 @@ def fetch_card(
     latest_print_id = json.get('data').get('attributes').get('latest_printing_id')
     card_art_bytes = request_api(NRO_PROXY_URL_TEMPLATE.format(print_id=latest_print_id)).content
 
-    if card_art_bytes is not None:
-        # The NRO proxy serves WebP; detect the real type rather than assuming .png,
-        # so the file extension always matches its actual content.
-        kind = filetype.guess(card_art_bytes)
-        extension = f'.{kind.extension}' if kind else '.png'
+    if not card_art_bytes:
+        raise ValueError(f"NRO proxy returned an empty response for print_id '{latest_print_id}' (name='{name}')")
 
-        # Save image based on quantity
-        for counter in range(quantity):
-            image_path = path.join(front_img_dir, OUTPUT_CARD_ART_FILE_TEMPLATE.format(deck_index=str(index), card_name=sanitized, quantity_counter=str(counter+1), extension=extension))
+    # The NRO proxy serves WebP; detect the real type rather than assuming .png,
+    # so the file extension always matches its actual content.
+    extension = guess_extension(card_art_bytes)
 
-            with open(image_path, 'wb') as f:
-                f.write(card_art_bytes)
+    # Save image based on quantity
+    for counter in range(quantity):
+        image_path = path.join(front_img_dir, OUTPUT_CARD_ART_FILE_TEMPLATE.format(deck_index=str(index), card_name=sanitized, quantity_counter=str(counter+1), extension=extension))
+
+        with open(image_path, 'wb') as f:
+            f.write(card_art_bytes)
 
 def is_valid_set(set_name: str) -> bool:
     # Attempt to query for set info

--- a/plugins/netrunner/api.py
+++ b/plugins/netrunner/api.py
@@ -1,8 +1,11 @@
+from io import BytesIO
 from os import path
 from requests import Response, Session
 from time import sleep
 from re import sub
 from unicodedata import normalize, category
+
+from PIL import Image
 
 session = Session()
 
@@ -41,16 +44,17 @@ def fetch_card(
 
     # Get the latest printing id
     latest_print_id = json.get('data').get('attributes').get('latest_printing_id')
-    card_art = request_api(NRO_PROXY_URL_TEMPLATE.format(print_id=latest_print_id)).content
+    card_art_bytes = request_api(NRO_PROXY_URL_TEMPLATE.format(print_id=latest_print_id)).content
 
-    if card_art is not None:
+    if card_art_bytes is not None:
+        # Decode the webp image and convert it to a real PNG
+        card_art = Image.open(BytesIO(card_art_bytes)).convert('RGBA')
 
         # Save image based on quantity
         for counter in range(quantity):
             image_path = path.join(front_img_dir, OUTPUT_CARD_ART_FILE_TEMPLATE.format(deck_index=str(index), card_name=sanitized, quantity_counter=str(counter+1)))
 
-            with open(image_path, 'wb') as f:
-                f.write(card_art)
+            card_art.save(image_path, format='PNG')
 
 def is_valid_set(set_name: str) -> bool:
     # Attempt to query for set info

--- a/plugins/netrunner/api.py
+++ b/plugins/netrunner/api.py
@@ -6,8 +6,8 @@ from unicodedata import normalize, category
 
 session = Session()
 
-NETRUNNERDB_SET_URL_TEMPLATE = 'https://api-preview.netrunnerdb.com/api/v3/public/card_sets/{set_name}'
-NETRUNNERDB_URL_TEMPLATE = 'https://api-preview.netrunnerdb.com/api/v3/public/cards/{card_name}'
+NETRUNNERDB_SET_URL_TEMPLATE = 'https://api.netrunnerdb.com/api/v3/public/card_sets/{set_name}'
+NETRUNNERDB_URL_TEMPLATE = 'https://api.netrunnerdb.com/api/v3/public/cards/{card_name}'
 NRO_PROXY_URL_TEMPLATE = 'https://nro-public.s3.nl-ams.scw.cloud/nro/card-printings/v2/webp/english/card/{print_id}.webp'
 
 OUTPUT_CARD_ART_FILE_TEMPLATE = '{deck_index}{card_name}{quantity_counter}.png'

--- a/plugins/netrunner/api.py
+++ b/plugins/netrunner/api.py
@@ -1,11 +1,10 @@
-from io import BytesIO
 from os import path
 from requests import Response, Session
 from time import sleep
 from re import sub
 from unicodedata import normalize, category
 
-from PIL import Image
+import filetype
 
 session = Session()
 
@@ -13,7 +12,7 @@ NETRUNNERDB_SET_URL_TEMPLATE = 'https://api.netrunnerdb.com/api/v3/public/card_s
 NETRUNNERDB_URL_TEMPLATE = 'https://api.netrunnerdb.com/api/v3/public/cards/{card_name}'
 NRO_PROXY_URL_TEMPLATE = 'https://nro-public.s3.nl-ams.scw.cloud/nro/card-printings/v2/webp/english/card/{print_id}.webp'
 
-OUTPUT_CARD_ART_FILE_TEMPLATE = '{deck_index}{card_name}{quantity_counter}.png'
+OUTPUT_CARD_ART_FILE_TEMPLATE = '{deck_index}{card_name}{quantity_counter}{extension}'
 
 def request_api(query: str) -> Response:
     r = session.get(query, headers = {'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
@@ -47,14 +46,17 @@ def fetch_card(
     card_art_bytes = request_api(NRO_PROXY_URL_TEMPLATE.format(print_id=latest_print_id)).content
 
     if card_art_bytes is not None:
-        # Decode the webp image and convert it to a real PNG
-        card_art = Image.open(BytesIO(card_art_bytes)).convert('RGBA')
+        # The NRO proxy serves WebP; detect the real type rather than assuming .png,
+        # so the file extension always matches its actual content.
+        kind = filetype.guess(card_art_bytes)
+        extension = f'.{kind.extension}' if kind else '.png'
 
         # Save image based on quantity
         for counter in range(quantity):
-            image_path = path.join(front_img_dir, OUTPUT_CARD_ART_FILE_TEMPLATE.format(deck_index=str(index), card_name=sanitized, quantity_counter=str(counter+1)))
+            image_path = path.join(front_img_dir, OUTPUT_CARD_ART_FILE_TEMPLATE.format(deck_index=str(index), card_name=sanitized, quantity_counter=str(counter+1), extension=extension))
 
-            card_art.save(image_path, format='PNG')
+            with open(image_path, 'wb') as f:
+                f.write(card_art_bytes)
 
 def is_valid_set(set_name: str) -> bool:
     # Attempt to query for set info

--- a/plugins/netrunner/fetch.py
+++ b/plugins/netrunner/fetch.py
@@ -8,7 +8,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.netrunner.deck_formats import DeckFormat, parse_deck
 from plugins.netrunner.api import get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = path.join(REPO_ROOT, 'game', 'front')
 
@@ -28,4 +28,5 @@ def cli(deck_path: str, format: DeckFormat):
         parse_deck(deck_text, format, get_handle_card( front_directory ))
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/one_piece/fetch.py
+++ b/plugins/one_piece/fetch.py
@@ -8,7 +8,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.one_piece.deck_formats import DeckFormat, parse_deck
 from plugins.one_piece.one_piece import get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = path.join(REPO_ROOT, 'game', 'front')
 
@@ -28,4 +28,5 @@ def cli(deck_path: str, format: DeckFormat):
         parse_deck(deck_text, format, get_handle_card(front_directory))
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/pokemon/fetch.py
+++ b/plugins/pokemon/fetch.py
@@ -8,7 +8,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.pokemon.deck_formats import DeckFormat, parse_deck
 from plugins.pokemon.limitless import get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = path.join(REPO_ROOT, 'game', 'front')
 
@@ -28,4 +28,5 @@ def cli(deck_path: str, format: DeckFormat):
         parse_deck(deck_text, format, get_handle_card(front_directory))
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/pokemon/limitless.py
+++ b/plugins/pokemon/limitless.py
@@ -2,7 +2,8 @@ from os import path
 from requests import Response, Session
 from requests.exceptions import HTTPError
 from time import sleep
-import filetype
+
+from utilities import guess_extension
 
 LIMITLESS_TCG_URL_TEMPLATE = 'https://limitlesstcg.nyc3.cdn.digitaloceanspaces.com/tpci/{set_id}/{set_id}_{card_no}_R_EN_LG.png'
 
@@ -125,10 +126,10 @@ def fetch_card(
         except Exception as e:
             raise Exception(f'Failed to fetch card "{card_name}" (set: {set_id}, number: {card_number}): {e}')
 
-    file_ext = filetype.guess(card_art).extension
+    extension = guess_extension(card_art)
 
     for counter in range(quantity):
-        image_path = path.join(front_img_dir, f'{str(index)}{card_name}{str(counter + 1)}.{file_ext}')
+        image_path = path.join(front_img_dir, f'{str(index)}{card_name}{str(counter + 1)}{extension}')
 
         with open(image_path, 'wb') as f:
             f.write(card_art)

--- a/plugins/riftbound/fetch.py
+++ b/plugins/riftbound/fetch.py
@@ -8,7 +8,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.riftbound.deck_formats import DeckFormat, parse_deck
 from plugins.riftbound.api import fetch_card_art, ImageServer, get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = path.join(REPO_ROOT, 'game', 'front')
 double_sided_directory = path.join(REPO_ROOT, 'game', 'double_sided')
@@ -38,4 +38,5 @@ def cli(deck_path: str, format: DeckFormat, source: ImageServer):
         )
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/sorcery_contested_realm/fetch.py
+++ b/plugins/sorcery_contested_realm/fetch.py
@@ -8,7 +8,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.sorcery_contested_realm.deck_formats import DeckFormat, parse_deck
 from plugins.sorcery_contested_realm.curiosa import get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = path.join(REPO_ROOT, 'game', 'front')
 
@@ -25,4 +25,5 @@ def cli(deck_path: str, format: DeckFormat):
     parse_deck(deck_path, format, get_handle_card(front_directory))
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/star_wars_unlimited/fetch.py
+++ b/plugins/star_wars_unlimited/fetch.py
@@ -8,7 +8,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.star_wars_unlimited.deck_formats import DeckFormat, parse_deck
 from plugins.star_wars_unlimited.swudb import get_handle_card
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = path.join(REPO_ROOT, 'game', 'front')
 double_sided_directory = path.join(REPO_ROOT, 'game', 'double_sided')
@@ -30,4 +30,5 @@ def cli(deck_path: str, format: DeckFormat):
         parse_deck(deck_text, format, get_handle_card(front_directory, double_sided_directory))
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/plugins/yugioh/fetch.py
+++ b/plugins/yugioh/fetch.py
@@ -8,7 +8,7 @@ sys.path.insert(0, REPO_ROOT)
 
 from plugins.yugioh.deck_formats import DeckFormat, parse_deck
 from plugins.yugioh.ygoprodeck import fetch_card_art
-from utilities import ensure_directory
+from utilities import configure_console_encoding, ensure_directory
 
 front_directory = os.path.join(REPO_ROOT, 'game', 'front')
 double_sided_directory = os.path.join(REPO_ROOT, 'game', 'double_sided')
@@ -30,4 +30,5 @@ def cli(deck_path: str, format: DeckFormat):
         fetch_card_art(passcode, quantity, front_directory)
 
 if __name__ == '__main__':
+    configure_console_encoding()
     cli()

--- a/test/test_netrunner_plugin.py
+++ b/test/test_netrunner_plugin.py
@@ -152,7 +152,7 @@ class TestNetrunnerAPI:
 
     def test_nro_api_availability(self):
         """Test that NRO Proxy API is available and responding."""
-        response = request_api("https://api-preview.netrunnerdb.com/api/v3/public/cards/hedge_fund")
+        response = request_api("https://api.netrunnerdb.com/api/v3/public/cards/hedge_fund")
         assert response.status_code == 200
 
 

--- a/utilities.py
+++ b/utilities.py
@@ -19,18 +19,17 @@ import page_manager
 import size_convert
 from enums import Registration, Orientation, OrientationMode, Variant
 
-# Some card names/symbols contain non-ASCII characters (e.g. diacritics, suit
-# pips) that can't be encoded by narrower legacy console codepages such as
-# Windows' cp1252. Reconfigure stdout/stderr to use UTF-8 so printing them
-# doesn't crash with a UnicodeEncodeError. Fall back silently if the stream
-# doesn't support reconfiguration (e.g. when output is captured/replaced).
-for _stream in (sys.stdout, sys.stderr):
-    if hasattr(_stream, 'reconfigure'):
-        try:
-            _stream.reconfigure(encoding='utf-8', errors='backslashreplace')
-        except Exception:
-            pass
-del _stream
+def configure_console_encoding() -> None:
+    """Reconfigure stdout/stderr to UTF-8, so printing non-ASCII card names
+    doesn't crash with UnicodeEncodeError on narrow console codepages (e.g.
+    Windows cp1252). Call once at CLI startup, not at import time, so this
+    module doesn't rewrite an embedding process's stdout/stderr as a side effect."""
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, 'reconfigure'):
+            try:
+                stream.reconfigure(encoding='utf-8', errors='backslashreplace')
+            except Exception:
+                pass
 
 # Specify directory locations
 # Use Path(__file__).parent to ensure paths work regardless of where script is run from
@@ -79,6 +78,11 @@ valid_mimetypes = (
     "image/qoi",
     "image/dds"
 )
+
+def guess_extension(data: bytes, default: str = '.png') -> str:
+    """Sniff the file extension from raw image bytes, falling back to `default`."""
+    kind = filetype.guess(data)
+    return f'.{kind.extension}' if kind else default
 
 # Approximately 1.25mm of bleed assuming 300 PPI: ceil(1.25mm * 1in/25.4mm * 300ppi)
 MINIMUM_BLEED = 15

--- a/utilities.py
+++ b/utilities.py
@@ -30,6 +30,7 @@ for _stream in (sys.stdout, sys.stderr):
             _stream.reconfigure(encoding='utf-8', errors='backslashreplace')
         except Exception:
             pass
+del _stream
 
 # Specify directory locations
 # Use Path(__file__).parent to ensure paths work regardless of where script is run from

--- a/utilities.py
+++ b/utilities.py
@@ -5,6 +5,7 @@ import math
 import filetype
 import os
 import re
+import sys
 from glob import glob
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -17,6 +18,18 @@ from pydantic import BaseModel, model_validator
 import page_manager
 import size_convert
 from enums import Registration, Orientation, OrientationMode, Variant
+
+# Some card names/symbols contain non-ASCII characters (e.g. diacritics, suit
+# pips) that can't be encoded by narrower legacy console codepages such as
+# Windows' cp1252. Reconfigure stdout/stderr to use UTF-8 so printing them
+# doesn't crash with a UnicodeEncodeError. Fall back silently if the stream
+# doesn't support reconfiguration (e.g. when output is captured/replaced).
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, 'reconfigure'):
+        try:
+            _stream.reconfigure(encoding='utf-8', errors='backslashreplace')
+        except Exception:
+            pass
 
 # Specify directory locations
 # Use Path(__file__).parent to ensure paths work regardless of where script is run from


### PR DESCRIPTION
## Summary

Fixes the Netrunner plugin's card fetching, which was broken due to a stale API host, and hardens image saving and console output against encoding issues.

## Changes

**fix(netrunner): update api host**
- Updates `NETRUNNERDB_SET_URL_TEMPLATE` and `NETRUNNERDB_URL_TEMPLATE` in `plugins/netrunner/api.py` from the retired `api-preview.netrunnerdb.com` host to `api.netrunnerdb.com`.
- Updates the corresponding test in `test/test_netrunner_plugin.py` to hit the new host.

**fix(utilities): adds fetch fallback for non utf8 characters**
- In `utilities.py`, reconfigures `sys.stdout`/`sys.stderr` to UTF-8 (with `backslashreplace` error handling) at import time, so printing card names/symbols containing non-ASCII characters (diacritics, suit pips, etc.) no longer crashes with `UnicodeEncodeError` on narrower legacy console codepages (e.g. Windows `cp1252`). Falls back silently if the stream doesn't support reconfiguration.

**refactor(netrunner): adds png file conversion to downloaded images**
- In `plugins/netrunner/api.py`, card art fetched from the NRO proxy (WebP format) is now decoded via Pillow and re-saved as a real PNG, instead of writing the raw WebP bytes directly to a `.png`-named file. Prevents downstream tools that expect genuine PNG files from failing on mislabeled WebP data.

## Testing
- Updated/verified `test_nro_api_availability` against the new API host.