### PR TITLE
Add dependabot.yml, drop Python 3.8/3.9 support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      pip-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 10

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve patch/minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch/minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "silhouette-card-maker"
 version = "1.6.0"
 description = "Card maker tool for Silhouette cutting machines"
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 
 [tool.pytest.ini_options]
 testpaths = ["test"]


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly, grouped updates for `pip` and `github-actions`, so dependency bump PRs (like #177) follow an explicit policy instead of implicit defaults.
- Bumps `requires-python` from `>=3.8` to `>=3.12` in pyproject.toml, matching what CI actually tests (`3.12`/`3.13`/`3.14`) and what current pinned deps already require (e.g. `requests==2.33.0` needs `>=3.10`). Python 3.8 (EOL Oct 2024) and 3.9 (EOL Oct 2025) are both past upstream end-of-life. No CI matrix changes needed.
- Adds `.github/workflows/dependabot-auto-merge.yml`: patch/minor Dependabot PRs are auto-approved and set to auto-merge once required checks pass; major bumps are left for manual review.

## Repo settings changed alongside this PR (not in the diff)
- Enabled "Allow auto-merge" at the repo level (was off) — required for the auto-merge workflow to function.
- Added branch protection on `main` requiring `test-core (3.12)`, `test-core (3.13)`, `test-core (3.14)`, and `detect-plugin-changes` to pass before any merge — this is what makes "auto-merge" actually wait for CI instead of merging immediately, and now applies to all PRs, not just Dependabot's.

## Test plan
- [ ] CI passes on 3.12/3.13/3.14 (unchanged matrix)
- [ ] Confirm Dependabot opens a grouped PR on its next scheduled run
- [ ] Confirm `pip install .` fails clearly (not silently) on Python <3.12
- [ ] Open a throwaway patch-level Dependabot-style PR (or wait for a real one) and confirm it auto-approves + auto-merges only after all required checks are green
- [ ] Confirm a major-version Dependabot PR is left unmerged for manual review