### PR TITLE
Fix silent 0-byte card art writes on empty responses

### DIFF
--- a/plugins/altered/altered.py
+++ b/plugins/altered/altered.py
@@ -23,6 +23,8 @@ def fetch_card(
     # Query for card info
     json = request_altered(f'https://api.altered.gg/cards/{qr}').json()
     card_art = request_altered(json.get('imagePath')).content
+    if not card_art:
+        raise ValueError(f'Received an empty card art response for "{qr}"')
 
     for counter in range(quantity):
         image_path = path.join(front_img_dir, f'{str(index)}{qr}{str(counter + 1)}.png')

--- a/plugins/ashes_reborn/ashes.py
+++ b/plugins/ashes_reborn/ashes.py
@@ -43,13 +43,15 @@ def fetch_card_art(index: int, card_name: str, card_stub: str, quantity: int, so
     
     card_art = request_ashes(url_template.format(card_stub=card_stub)).content
 
-    if card_art is not None:
-        # Save image based on quantity
-        for counter in range(quantity):
-            image_path = path.join(front_img_dir, f'{index}{card_name}_{counter + 1}.png')
+    if not card_art:
+        raise ValueError(f'Received an empty card art response for "{card_name}" (stub: {card_stub})')
 
-            with open(image_path, 'wb') as f:
-                f.write(card_art)
+    # Save image based on quantity
+    for counter in range(quantity):
+        image_path = path.join(front_img_dir, f'{index}{card_name}_{counter + 1}.png')
+
+        with open(image_path, 'wb') as f:
+            f.write(card_art)
 
 def get_handle_card(
     source: ImageServer,

--- a/plugins/digimon/digimoncard.py
+++ b/plugins/digimon/digimoncard.py
@@ -20,13 +20,15 @@ def fetch_card_art(index: int, card_number: str, quantity: int, front_img_dir: s
 
     card_art = request_digimon(CARD_ART_URL_TEMPLATE.format(card_number=card_number)).content
 
-    if card_art is not None:
-        # Save image based on quantity
-        for counter in range(quantity):
-            image_path = path.join(front_img_dir, f'{index}{card_number}_{counter + 1}.jpg')
+    if not card_art:
+        raise ValueError(f'Received an empty card art response for card number "{card_number}"')
 
-            with open(image_path, 'wb') as f:
-                f.write(card_art)
+    # Save image based on quantity
+    for counter in range(quantity):
+        image_path = path.join(front_img_dir, f'{index}{card_number}_{counter + 1}.jpg')
+
+        with open(image_path, 'wb') as f:
+            f.write(card_art)
 
 def get_handle_card(
     front_img_dir: str

--- a/plugins/echoes_of_astra/api.py
+++ b/plugins/echoes_of_astra/api.py
@@ -48,6 +48,9 @@ def fetch_card(
     front_img_dir: str,
 ):
     card_art = request_astra(image_url).content
+    if not card_art:
+        raise ValueError(f'Received an empty card art response for "{card_name}"')
+
     clean_card_name = remove_nonalphanumeric(card_name)
 
     for counter in range(quantity):

--- a/plugins/final_fantasy/fftcg.py
+++ b/plugins/final_fantasy/fftcg.py
@@ -64,6 +64,8 @@ def fetch_card(
     # Query for card info
     url = get_card_art_from_fftcg(card_name, serial_code, category)
     card_art = request_fftcg(url).content
+    if not card_art:
+        raise ValueError(f'Received an empty card art response for "{card_name}"')
 
     for counter in range(quantity):
         image_path = path.join(front_img_dir, f'{str(index)}{card_name}{str(counter + 1)}.png')

--- a/plugins/flesh_and_blood/fabtcg.py
+++ b/plugins/flesh_and_blood/fabtcg.py
@@ -77,18 +77,17 @@ def fetch_card(
         raise ValueError(f"No printable face found for card_id '{card_id}' (name='{name}')")
 
     card_art_url = chosen_face.get('image', {}).get('normal')
-    card_art_response = request_fabtcg(card_art_url)
+    card_art = request_fabtcg(card_art_url).content
 
-    if card_art_response is not None:
-        card_art = card_art_response.content
+    if not card_art:
+        raise ValueError(f"Received an empty card art response for card_id '{card_id}' (name='{name}')")
 
-        if card_art is not None:
-            # Save image based on quantity
-            for counter in range(quantity):
-                image_path = path.join(front_img_dir, OUTPUT_CARD_ART_FILE_TEMPLATE.format(deck_index=str(index), card_name=sanitized, quantity_counter=str(counter+1)))
+    # Save image based on quantity
+    for counter in range(quantity):
+        image_path = path.join(front_img_dir, OUTPUT_CARD_ART_FILE_TEMPLATE.format(deck_index=str(index), card_name=sanitized, quantity_counter=str(counter+1)))
 
-                with open(image_path, 'wb') as f:
-                    f.write(card_art)
+        with open(image_path, 'wb') as f:
+            f.write(card_art)
 
 def get_handle_card(
     front_img_dir: str,

--- a/plugins/grand_archive/gatcg.py
+++ b/plugins/grand_archive/gatcg.py
@@ -32,18 +32,17 @@ def fetch_card(
     name_response = request_gatcg(CARD_URL_TEMPLATE.format(name=slugified))
 
     card_art_url = name_response.json().get('editions', [{}])[0].get('image')
-    art_response = request_gatcg(CARD_ART_URL_TEMPLATE.format(card_art_suffix=card_art_url))
-    
-    if art_response is not None:
-        card_art = art_response.content
+    card_art = request_gatcg(CARD_ART_URL_TEMPLATE.format(card_art_suffix=card_art_url)).content
 
-        if card_art is not None:
-            # Save image based on quantity
-            for counter in range(quantity):
-                image_path = path.join(front_img_dir, OUTPUT_CARD_ART_FILE_TEMPLATE.format(deck_index=str(index), card_name=card_name, quantity_counter=str(counter + 1)))
+    if not card_art:
+        raise ValueError(f'Received an empty card art response for "{card_name}"')
 
-                with open(image_path, 'wb') as f:
-                    f.write(card_art)
+    # Save image based on quantity
+    for counter in range(quantity):
+        image_path = path.join(front_img_dir, OUTPUT_CARD_ART_FILE_TEMPLATE.format(deck_index=str(index), card_name=card_name, quantity_counter=str(counter + 1)))
+
+        with open(image_path, 'wb') as f:
+            f.write(card_art)
 
 def get_handle_card(
     front_img_dir: str,

--- a/plugins/gundam/gundam.py
+++ b/plugins/gundam/gundam.py
@@ -26,14 +26,16 @@ def fetch_card(
 ):
     # Query for card info
     card_art = request_bandai(CARD_ART_URL_TEMPLATE.format(card_number=card_number)).content
-    
-    if card_art is not None:
-        # Save image based on quantity
-        for counter in range(quantity):
-            image_path = path.join(front_img_dir, OUTPUT_CARD_ART_FILE_TEMPLATE.format(deck_index=str(index), card_number=card_number, quantity_counter=str(counter + 1)))
 
-            with open(image_path, 'wb') as f:
-                f.write(card_art)
+    if not card_art:
+        raise ValueError(f'Received an empty card art response for card number "{card_number}"')
+
+    # Save image based on quantity
+    for counter in range(quantity):
+        image_path = path.join(front_img_dir, OUTPUT_CARD_ART_FILE_TEMPLATE.format(deck_index=str(index), card_number=card_number, quantity_counter=str(counter + 1)))
+
+        with open(image_path, 'wb') as f:
+            f.write(card_art)
 
 def get_handle_card(
     front_img_dir: str,

--- a/plugins/mtg/deck_formats.py
+++ b/plugins/mtg/deck_formats.py
@@ -232,6 +232,8 @@ def parse_scryfall_json(deck_text, handle_card: Callable, front_img_dir: str = '
                 if front_url:
                     response = requests.get(front_url, headers={'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
                     response.raise_for_status()
+                    if not response.content:
+                        raise ValueError(f'Received an empty card art response for "{name}"')
                     for counter in range(quantity):
                         with open(os.path.join(front_img_dir, f'{index}{clean_name}{counter + 1}.png'), 'wb') as f:
                             f.write(response.content)
@@ -240,6 +242,8 @@ def parse_scryfall_json(deck_text, handle_card: Callable, front_img_dir: str = '
                 if back_url and double_sided_dir:
                     response = requests.get(back_url, headers={'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
                     response.raise_for_status()
+                    if not response.content:
+                        raise ValueError(f'Received an empty back-face card art response for "{name}"')
                     for counter in range(quantity):
                         with open(os.path.join(double_sided_dir, f'{index}{clean_name}{counter + 1}.png'), 'wb') as f:
                             f.write(response.content)
@@ -370,6 +374,8 @@ def parse_cubecobra_csv(deck_text, handle_card: Callable, front_img_dir: str, do
                 clean_name = remove_nonalphanumeric(name)
                 response = requests.get(image_url, headers={'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
                 response.raise_for_status()
+                if not response.content:
+                    raise ValueError(f'Received an empty card art response for "{name}"')
                 kind = filetype.guess(response.content)
                 ext = f'.{kind.extension}' if kind else '.png'
                 for counter in range(quantity):
@@ -381,6 +387,8 @@ def parse_cubecobra_csv(deck_text, handle_card: Callable, front_img_dir: str, do
                     print(f'Fetching back image from URL: {image_back_url}')
                     back_response = requests.get(image_back_url, headers={'user-agent': 'silhouette-card-maker/0.1', 'accept': '*/*'})
                     back_response.raise_for_status()
+                    if not back_response.content:
+                        raise ValueError(f'Received an empty back-face card art response for "{name}"')
                     back_kind = filetype.guess(back_response.content)
                     back_ext = f'.{back_kind.extension}' if back_kind else '.png'
                     for counter in range(quantity):

--- a/plugins/mtg/scryfall.py
+++ b/plugins/mtg/scryfall.py
@@ -175,8 +175,9 @@ def fetch_card_art(
 ) -> None:
     # Query for the front side
     card_art = fetch_image(card_set, card_collector_number, prefer_langs)
-    if card_art is not None:
-        save_card_art_copies(card_art, front_img_dir, index, clean_card_name, quantity)
+    if not card_art:
+        raise ValueError(f'Received an empty card art response for "{clean_card_name}" (set: {card_set}, collector number: {card_collector_number})')
+    save_card_art_copies(card_art, front_img_dir, index, clean_card_name, quantity)
 
     # Get backside of card, if it exists
     if layout in double_sided_layouts:
@@ -185,8 +186,9 @@ def fetch_card_art(
                 fetch_meld_back(index, quantity, clean_card_name, card_name, all_parts, double_sided_dir)
         else:
             card_art = fetch_image(card_set, card_collector_number, prefer_langs, face='back')
-            if card_art is not None:
-                save_card_art_copies(card_art, double_sided_dir, index, clean_card_name, quantity)
+            if not card_art:
+                raise ValueError(f'Received an empty back-face card art response for "{clean_card_name}" (set: {card_set}, collector number: {card_collector_number})')
+            save_card_art_copies(card_art, double_sided_dir, index, clean_card_name, quantity)
 
 def partition_printings(printings: List, condition: List) -> Tuple[List, List]:
     matches = []

--- a/plugins/one_piece/one_piece.py
+++ b/plugins/one_piece/one_piece.py
@@ -27,14 +27,15 @@ def fetch_card(
     # Query for card art
     card_art = request_bandai(CARD_ART_URL_TEMPLATE.format(card_number=card_number)).content
 
-    if card_art is not None:
+    if not card_art:
+        raise ValueError(f'Received an empty card art response for card number "{card_number}"')
 
-        # Save image based on quantity
-        for counter in range(quantity):
-            image_path = path.join(front_img_dir, OUTPUT_CARD_ART_FILE_TEMPLATE.format(deck_index=str(index), card_number=card_number, quantity_counter=str(counter+1)))
+    # Save image based on quantity
+    for counter in range(quantity):
+        image_path = path.join(front_img_dir, OUTPUT_CARD_ART_FILE_TEMPLATE.format(deck_index=str(index), card_number=card_number, quantity_counter=str(counter+1)))
 
-            with open(image_path, 'wb') as f:
-                f.write(card_art)
+        with open(image_path, 'wb') as f:
+            f.write(card_art)
 
 def get_handle_card(
     front_img_dir: str,

--- a/plugins/riftbound/api.py
+++ b/plugins/riftbound/api.py
@@ -40,16 +40,17 @@ def fetch_card_art(index: int, card_number: str, quantity: int, source: ImageSer
             image_server_query = url_template.format(card_number=f'{match.group(1)}s')
             api_response = request_api(image_server_query)
 
-    if api_response is not None:
-        card_art = api_response.content
+    card_art = api_response.content
 
-        if card_art is not None:
-            # Save image based on quantity
-            for counter in range(quantity):
-                image_path = path.join(front_img_dir, f'{index}{card_number}_{counter + 1}.jpg')
+    if not card_art:
+        raise ValueError(f'Received an empty card art response for card number "{card_number}"')
 
-                with open(image_path, 'wb') as f:
-                    f.write(card_art)
+    # Save image based on quantity
+    for counter in range(quantity):
+        image_path = path.join(front_img_dir, f'{index}{card_number}_{counter + 1}.jpg')
+
+        with open(image_path, 'wb') as f:
+            f.write(card_art)
 
 def fetch_card_number(name: str) -> str:
     url = f"https://riftmana.com/wp-json/wp/v2/cards?search={name}"

--- a/plugins/sorcery_contested_realm/curiosa.py
+++ b/plugins/sorcery_contested_realm/curiosa.py
@@ -63,6 +63,9 @@ def fetch_card(
     front_img_dir: str,
 ):
     card_art = request_curiosa(image_url).content
+    if not card_art:
+        raise ValueError(f'Received an empty card art response for "{card_name}"')
+
     clean_name = remove_nonalphanumeric(card_name)
 
     for counter in range(quantity):

--- a/plugins/star_wars_unlimited/swudb.py
+++ b/plugins/star_wars_unlimited/swudb.py
@@ -74,11 +74,16 @@ def fetch_card(
 
     printing = printings[0]
     front_art = request_swudb(SWUDB_ART_URL_TEMPLATE.format(card_art_ref=sub('.+cards/', '', printing.get('frontImagePath')))).content
+    if not front_art:
+        raise ValueError(f'Received an empty card art response for "{name}"')
+
     back_art = None
 
     back_image_path = printing.get('backImagePath', '')
     if back_image_path:
         back_art = request_swudb(SWUDB_ART_URL_TEMPLATE.format(card_art_ref=sub('.+cards/', '', back_image_path))).content
+        if not back_art:
+            raise ValueError(f'Received an empty back-face card art response for "{name}"')
 
     # Save images based on quantity
     for counter in range(quantity):

--- a/plugins/yugioh/ygoprodeck.py
+++ b/plugins/yugioh/ygoprodeck.py
@@ -17,13 +17,14 @@ def request_api(query: str) -> requests.Response:
 def fetch_card_art(passcode: int, quantity: int, front_img_dir: str):
     card_front_image_query = f'https://images.ygoprodeck.com/images/cards/{passcode}.jpg'
     card_art = request_api(card_front_image_query).content
-    if card_art is not None:
+    if not card_art:
+        raise ValueError(f'Received an empty card art response for passcode "{passcode}"')
 
-        # Save image based on quantity
-        for counter in range(quantity):
-            image_path = os.path.join(front_img_dir, f'{passcode}_{counter + 1}.jpg')
+    # Save image based on quantity
+    for counter in range(quantity):
+        image_path = os.path.join(front_img_dir, f'{passcode}_{counter + 1}.jpg')
 
-            with open(image_path, 'wb') as f:
-                f.write(card_art)
+        with open(image_path, 'wb') as f:
+            f.write(card_art)
 
-            print(f'{image_path}')
+        print(f'{image_path}')


### PR DESCRIPTION
## Summary
- Several plugins fetch card art via `response.content` and guard the save with `if card_art is not None:` (or `!= None`, or no guard at all). None of these catch an HTTP 200 with an empty body: `requests.Response.content` is `b''`, not `None`, in that case, so the check passes and a zero-byte, valid-looking image file gets written with no error. This mirrors the netrunner bug fixed in #185.
- Also collapsed a few outer `if response is not None:` checks (grand_archive, riftbound, flesh_and_blood/fabtcg) as part of the fix, since the `request_*()` helpers they guard always either return a `Response` or raise via `raise_for_status()` - they can never actually return `None`, so those checks were dead code wrapping the real (empty-content) bug.
- Affected: altered, ashes_reborn, digimon, echoes_of_astra, final_fantasy, flesh_and_blood, grand_archive, gundam, mtg (`scryfall.py` and both URL-direct fetch paths in `deck_formats.py`), one_piece, riftbound, sorcery_contested_realm, star_wars_unlimited, yugioh.

## Test plan
- [x] Verified with mocked empty-content responses that each fixed path now raises `ValueError` instead of writing a corrupt file (spot-checked gundam, riftbound, mtg/scryfall, star_wars_unlimited).
- [x] Ran the full test suite: 10 pre-existing failures (dead third-party APIs for altered/echoes_of_astra/curiosa, an unrelated `NameError` in `curiosa.py`, and a Windows filename bug in star_wars_unlimited unrelated to the code touched here) - confirmed identical on `main` before this change via `git stash`.